### PR TITLE
fix: use script-local variable instead of global v:shell_error

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -98,6 +98,7 @@ function! llama#init()
     let s:t_last_move = reltime() " last time the cursor moved
 
     let s:current_job = v:null
+    let s:job_error = 0
 
     let s:ghost_text_nvim = exists('*nvim_buf_get_mark')
     let s:ghost_text_vim = has('textprop')
@@ -435,6 +436,7 @@ function! llama#fim(is_auto) abort
             call job_stop(s:current_job)
         endif
     endif
+    let s:job_error = 0
 
     " send the request asynchronously
     if s:ghost_text_nvim
@@ -532,7 +534,7 @@ function! s:fim_on_stdout(pos_x, pos_y, is_auto, job_id, data, event = v:null)
         return
     endif
 
-    if v:shell_error || len(l:raw) == 0
+    if s:job_error || len(l:raw) == 0
         let l:raw = json_encode({'content': '  llama.vim : cannot reach llama.cpp server. (:help llama)'})
 
         let s:can_accept = v:false
@@ -744,5 +746,6 @@ function! s:fim_on_exit(job_id, exit_code, event = v:null)
         echom "Job failed with exit code: " . a:exit_code
     endif
 
+    let s:job_error = a:exit_code
     let s:current_job = v:null
 endfunction


### PR DESCRIPTION
Hi, thank you for this plugin. 

I had issues integrating it into my config. Although it works great on a fresh install of neovim, it seems that the variable `v:shell_error` used in `llama#fim_on_stdout` can be overwritten by other processes launched before processing of the `curl` job's stdout. 
In my case, it seems to be a conflict with the plugin [nvim-tree](https://github.com/nvim-tree/nvim-tree.lua). Adding debug logs in `llama.vim` showed that `v:shell_error` was 128, even though `l:raw` was the expected `curl` JSON output.

I have added a script-local `s:job_error`. It is:
- set to 0 when starting a FIM request job,
- set to the job's exit code in `llama#fim_on_exit`,
- checked in `llama#fim_on_stdout` instead of checking `v:shell_error`.

Also, I'm not sure if this check is really necessary, it seems to work fine when just removing the check on `v:shell_error` (or on my `s:job_error`), i.e. just checking if the length of `curl`'s stdout is 0:

```vimscript
  if len(l:raw) == 0
        let l:raw = json_encode({'content': '  llama.vim : cannot reach llama.cpp server. (:help llama)'})
        ...
```
I chose to go with `s:job_error` instead, because I'm not sure if `curl` can ever write anything to stdout while returning an error exit code. 