### PR TITLE
Bugfix : classic vim suffix duplicate

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -727,7 +727,6 @@ function! s:fim_on_stdout(pos_x, pos_y, is_auto, job_id, data, event = v:null)
             call prop_add(s:pos_y, 0, {
                 \ 'type': s:hlgroup_info,
                 \ 'text': l:info,
-                \ 'text_padding_left': col('$'),
                 \ 'text_wrap': 'truncate'
                 \ })
         endif

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -707,8 +707,9 @@ function! s:fim_on_stdout(pos_x, pos_y, is_auto, job_id, data, event = v:null)
             \ 'virt_text_win_col': virtcol('.')
             \ })
     elseif s:ghost_text_vim
-        let l:new_suffix = s:content[0]
-        if !empty(l:new_suffix)
+        let l:full_suffix = s:content[0]
+        if !empty(l:full_suffix)
+	    let l:new_suffix = l:full_suffix[0:-len(getline('.')[col('.')-1:])-1]
             call prop_add(s:pos_y, s:pos_x + 1, {
                 \ 'type': s:hlgroup_hint,
                 \ 'text': l:new_suffix


### PR DESCRIPTION
Before bugfix:
![before](https://github.com/user-attachments/assets/e1f832b2-d938-4a99-87c8-24538244375e)


After bugfix:
![after](https://github.com/user-attachments/assets/b5a0b905-d70f-487c-89ce-afd1f8c83047)
