### PR TITLE
add Vundle instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,34 @@ Local LLM-assisted text completion.
 
 ## Installation
 
-### vim-plug
+### Plugin setup
+
+#### vim-plug
 
 ```vim
 Plug 'ggml-org/llama.vim'
 ```
 
+#### Vundle
+
+```bash
+cd ~/.vim/bundle
+git clone https://github.com/ggml-org/llama.vim
+```
+
+Then add `Plugin 'llama.vim'` to your *.vimrc* in the `vundle#begin()` section.
+
+### llama.cpp setup
+
 The plugin requires a [llama.cpp](https://github.com/ggerganov/llama.cpp) server instance to be running at [`g:llama_config.endpoint`](https://github.com/ggml-org/llama.vim/blob/7d3359077adbad4c05872653973c3ceb09f18ad9/autoload/llama.vim#L34-L36)
 
-### Mac OS
+#### Mac OS
 
 ```bash
 brew install llama.cpp
 ```
 
-### Any other OS
+#### Any other OS
 
 Either build from source or use the latest binaries: https://github.com/ggerganov/llama.cpp/releases
 


### PR DESCRIPTION
This PR adds instructions for installing the plugin in a vim setup that uses Vundle instead of vim-plug. It worked first try, so I thought other Vundle users might. However, I am not a Vundle expert by any means so I don't know if there is a better way, only that this way was easy and worked.

I also reorganized the installation instructions slightly to add a level of hierarchy because of this addition, since I thought the flat hierarchy might make people think all steps were required.

Very nice plugin by the way! I've been using classic vim for about 20 years now, so realistically I'm not going to change my ways except through vim plugins. :)