### PR TITLE
add_quotations

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -310,7 +310,7 @@ function! s:ring_update()
         \ "--request", "POST",
         \ "--url", g:llama_config.endpoint,
         \ "--header", "Content-Type: application/json",
-        \ "--data", l:request
+        \ "--data", "'". l:request ."'"
         \ ]
     if exists ("g:llama_config.api_key") && len("g:llama_config.api_key") > 0
         call extend(l:curl_command, ['--header', 'Authorization: Bearer ' .. g:llama_config.api_key])
@@ -423,7 +423,7 @@ function! llama#fim(is_auto) abort
         \ "--request", "POST",
         \ "--url", g:llama_config.endpoint,
         \ "--header", "Content-Type: application/json",
-        \ "--data", l:request
+        \ "--data", "'". l:request ."'"
         \ ]
     if exists ("g:llama_config.api_key") && len("g:llama_config.api_key") > 0
         call extend(l:curl_command, ['--header', 'Authorization: Bearer ' .. g:llama_config.api_key])


### PR DESCRIPTION
The quotation marks around `l:request` are important when sending the `curl_command` through `ssh`, for instance, as in:

```vimscript
let l:curl_command = [
        \ "ssh", "-q",
        \ "-J", "jump.server",
        \ "llama.cpp.server",
        \ "curl",
        \ "--silent",
        \ "--no-buffer",
        \ "--request", "POST",
        \ "--url", g:llama_config.endpoint,
        \ "--header", "Content-Type: application/json",
        \ "--data", "'". l:request ."'"
        \ ]
```
Without the quotation marks, the ssh command might fail, hence this PR. 

## Why would you need that?

On a server cluster, you might want to run the llama.cpp server on one server and work on a file in vim on another server. Then you need to route your `curl` command to the llama.cpp server (possibly via a jump server) to use the curl command as is. 

This should not affect the generality of the `curl_command`. Putting this here because it took me a while to figure out.