### PR TITLE
cache: keep cached suggestions

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -361,6 +361,7 @@ function! llama#fim(is_auto) abort
     endif
 
     let s:t_fim_start = reltime()
+
     let s:content = []
     let s:can_accept = v:false
 
@@ -450,7 +451,6 @@ function! llama#fim(is_auto) abort
 
     " Check if the completion is cached
     let l:cached_completion = get(g:result_cache, l:hash , v:null)
-
 
     " ... or if there is a cached completion nearby (10 characters behind)
     " Looks at the previous 10 characters to see if a completion is cached. If one is found at (x,y)
@@ -578,6 +578,7 @@ function! s:on_move()
     call llama#fim_cancel()
 endfunction
 
+" TODO: Currently the cache uses a random eviction policy. A more clever policy could be implemented (eg. LRU).
 function! s:insert_cache(key, value)
     if len(keys(g:result_cache)) > (g:llama_config.max_cache_keys - 1)
         let l:keys = keys(g:result_cache)
@@ -590,7 +591,6 @@ endfunction
 " callback that processes the FIM result from the server and displays the suggestion
 function! s:fim_on_stdout(hash, pos_x, pos_y, is_auto, job_id, data, event = v:null)
     " Retrieve the FIM result from cache
-    " TODO: Currently the cache uses a random eviction policy. A more clever policy could be implemented (eg. LRU).
     if has_key(g:result_cache, a:hash)
         let l:raw = get(g:result_cache, a:hash)
     else
@@ -635,7 +635,6 @@ function! s:fim_on_stdout(hash, pos_x, pos_y, is_auto, job_id, data, event = v:n
     let l:n_predict    = 0
     let l:t_predict_ms = 1.0
     let l:s_predict    = 0
-
 
     " get the generated suggestion
     if s:can_accept
@@ -738,7 +737,6 @@ function! s:fim_on_stdout(hash, pos_x, pos_y, is_auto, job_id, data, event = v:n
     let s:pos_dx = len(s:content[-1])
 
     let s:content[-1] .= s:line_cur_suffix
-
 
     call llama#fim_cancel()
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -478,7 +478,6 @@ function! llama#fim(is_auto) abort
     endif
     
     if l:cached_completion != v:null
-
         call s:fim_on_stdout(l:hash, s:pos_x, s:pos_y, a:is_auto, 0, l:cached_completion)
     else
         " send the request asynchronously

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -593,10 +593,8 @@ endfunction
 function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, event = v:null)
     " Retrieve the FIM result from cache
     if a:cache && has_key(g:result_cache, a:hash)
-        echom "cache hit"
         let l:raw = get(g:result_cache, a:hash)
     else
-        echom "cache miss"
         if s:ghost_text_nvim
             let l:raw = join(a:data, "\n")
         elseif s:ghost_text_vim


### PR DESCRIPTION
This PR aims to optimize the performance of the cache such that when the user types the same letter as the current cached suggestion, we keep the suggestion displayed instead of going to the server to fetch a new FIM completion. 

Here's how it works:
The initial completion shown below is cached.
<img width="1089" alt="Screen Shot 2025-01-02 at 10 35 43 PM" src="https://github.com/user-attachments/assets/e36dd0e0-8a65-4d90-ac81-188cbe56e460" />

As the user continues typing out the current suggestion, we scan back 10 characters to see if there is a cached suggestion nearby. If the cached suggestion matches what the user typed, it is kept. This approach works better than simply checking to see if the previous character is cached because if the user types fast enough `llama#fim()` will not get called and will result in a cache miss.
<img width="1086" alt="Screen Shot 2025-01-02 at 10 43 31 PM" src="https://github.com/user-attachments/assets/934854f5-4297-420d-903b-1d42ce415491" />



Changes in this PR:
- Modified the format of the cache key from `l:prefix . "|" . l:suffix . "|" . l:prompt` to `l:prefix . l:prompt . l:suffix`. It seems more intuitive to keep the prompt in the middle with the prefix and suffix on either side.
- Created a separate function to insert items into the cache.
- Search for cached values nearby for zero-latency suggestions.

Fixes #16 