### PR TITLE
info: cached info message

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -614,7 +614,6 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
         elseif s:ghost_text_vim
             let l:raw = a:data
         endif
-        call s:insert_cache(a:hash, l:raw)
         let l:is_cached = v:false
     endif
 
@@ -627,6 +626,10 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
 
     if len(l:raw) == 0
         return
+    endif
+
+    if !l:is_cached
+        call s:insert_cache(a:hash, l:raw)
     endif
 
     let s:pos_x = a:pos_x

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -586,7 +586,7 @@ function! s:insert_cache(key, value)
         let l:hash = l:keys[rand() % len(l:keys)]
         call remove(g:result_cache, l:hash)
     endif
-    " put just the raw content in the cache
+    " put just the raw content in the cache without metrics
     let l:parsed_value = json_decode(a:value)
     let l:stripped_content = get(l:parsed_value, 'content', '')
     let g:result_cache[a:key] = json_encode({'content': l:stripped_content})
@@ -594,6 +594,7 @@ endfunction
 
 " callback that processes the FIM result from the server and displays the suggestion
 function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, event = v:null)
+    " make sure cursor position hasn't changed since fim_on_stdout was triggered
     if a:pos_x != col('.') - 1 || a:pos_y != line('.')
         return
     endif
@@ -645,6 +646,7 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
     " get the generated suggestion
     if s:can_accept
         let l:response = json_decode(l:raw)
+
         for l:part in split(get(l:response, 'content', ''), "\n", 1)
             call add(s:content, l:part)
         endfor
@@ -674,6 +676,7 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
             let l:s_predict    = get(l:timings, 'predicted_per_second', 0)
         endif
 
+        " if response was pulled from cache
         if l:is_cached
             let l:has_info = v:true
         endif
@@ -757,9 +760,8 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
     endif
 
     let l:info = ''
-    " construct the info message
-    echom l:has_info
 
+    " construct the info message
     if g:llama_config.show_info > 0 && l:has_info
         let l:prefix = '   '
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -594,6 +594,7 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
     " Retrieve the FIM result from cache
     if a:cache && has_key(g:result_cache, a:hash)
         let l:raw = get(g:result_cache, a:hash)
+        let l:is_cached = v:true
     else
         if s:ghost_text_nvim
             let l:raw = join(a:data, "\n")
@@ -601,6 +602,7 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
             let l:raw = a:data
         endif
         call s:insert_cache(a:hash, l:raw)
+        let l:is_cached = v:false
     endif
 
     if a:pos_x != col('.') - 1 || a:pos_y != line('.')
@@ -758,6 +760,12 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
             let l:info = printf("%s | WARNING: the context is full: %d / %d, increase the server context size or reduce g:llama_config.ring_n_chunks",
                 \ g:llama_config.show_info == 2 ? l:prefix : 'llama.vim',
                 \ l:n_cached, l:n_ctx
+                \ )
+        elseif l:is_cached
+            let l:info = printf("%s | C: %d / %d, | t: %.2f ms",
+                \ g:llama_config.show_info == 2 ? l:prefix : 'llama.vim',
+                \ len(keys(g:result_cache)), g:llama_config.max_cache_keys,
+                \ 1000.0 * reltimefloat(reltime(s:t_fim_start))
                 \ )
         else
             let l:info = printf("%s | c: %d / %d, r: %d / %d, e: %d, q: %d / 16 | p: %d (%.2f ms, %.2f t/s) | g: %d (%.2f ms, %.2f t/s) | t: %.2f ms",


### PR DESCRIPTION
Instead of displaying the original response metrics when the completion was pulled from cache, we want to display metrics related to the cache. The completion info is shown in the following format:

C:  number of elements currently in the cache / cache size
t: total FIM time

```
 ... world\n");     | C: 3 / 250 | t: 0.66 ms
```
This is what the info message looks like when there is a cache hit.
<img width="719" alt="Screen Shot 2025-01-05 at 2 42 25 AM" src="https://github.com/user-attachments/assets/92be528f-72c9-4ef7-a7a3-5525e489acff" />

Changes in this PR:
- Changed info message for when there is a cache hit
- Optimized cache usage by only storing the `content` and not the other metrics. This helps reduce the size of the cache.


This suggestion was mentioned here: https://github.com/ggml-org/llama.vim/pull/18#pullrequestreview-2530402352