### PR TITLE
allow to specify partial config

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -51,7 +51,8 @@ let s:default_config = {
     \ 'ring_update_ms':   1000,
     \ }
 
-let g:llama_config = get(g:, 'llama_config', s:default_config)
+let llama_config = get(g:, 'llama_config', s:default_config)
+let g:llama_config = extendnew(s:default_config, llama_config, 'force')
 
 let g:result_cache = {}
 


### PR DESCRIPTION
Currently when customizing **llama_config** we need to specify all the config keys, this PR allows the user to specify only the part they want to change, which will then be merged (override) with the default config.