### PR TITLE
llama.vim: speculative fim

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -36,7 +36,7 @@ highlight llama_hl_info guifg=#77ff2f ctermfg=119
 let s:default_config = {
     \ 'endpoint':         'http://127.0.0.1:8012/infill',
     \ 'api_key':          '',
-    \ 'n_prefix':         256, 
+    \ 'n_prefix':         256,
     \ 'n_suffix':         64,
     \ 'n_predict':        128,
     \ 't_max_prompt_ms':  500,
@@ -103,7 +103,7 @@ function! llama#init()
 
     let s:current_job = v:null
     let s:job_error = 0
-    
+
     let s:ghost_text_nvim = exists('*nvim_buf_get_mark')
     let s:ghost_text_vim = has('textprop')
 


### PR DESCRIPTION
I propose an implementation for speculative fill in the middle. We now take advantage of the time the server is sitting idle while a suggestion is displayed to fetch the next completion assuming the user accepts the current one. This gives the illusion of (near) zero-latency suggestions to provide a better user experience.

It works by calculating the prefix, suffix, and prompt assuming the user accepts the current suggestion. Apart from a new  prefix, suffix, and prompt, it is nearly identical to `llama#fim()`. After a new fim completion is fetched, we cache it instead of displaying it to the user. So when they accept the current suggestion, the next completion will be a cache hit. 

I'm aware that a lot of the code in `llama#fim()` is duplicated in `llama#speculate()`. In most cases I would say it's better to modularize code, but here I think having two separate implementations makes it more readable, maintainable, and less messy. 

I'm open to suggestions on modularizing and implmention.  TAB, TAB, TAB!

https://github.com/user-attachments/assets/1d66eaa6-1c92-4799-bf31-2ed3217be5b6

