### PR TITLE
Update README.md to use main version of llama.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then add `Plugin 'llama.vim'` to your *.vimrc* in the `vundle#begin()` section.
 
 ### llama.cpp setup
 
-The plugin requires a [llama.cpp](https://github.com/ggerganov/llama.cpp) server instance to be running at [`g:llama_config.endpoint`](https://github.com/ggml-org/llama.vim/blob/7d3359077adbad4c05872653973c3ceb09f18ad9/autoload/llama.vim#L34-L36)
+The plugin requires a [llama.cpp](https://github.com/ggerganov/llama.cpp) server instance to be running at [`g:llama_config.endpoint`](https://github.com/ggml-org/llama.vim/blob/master/autoload/llama.vim#L37).
 
 #### Mac OS
 


### PR DESCRIPTION
The readme currently points at an old version of `autoload/llama.vim`. This version doesn't have all the required keys, so modifying it and adding it to .vimrc causes llama.vim to break. This PR updates the readme to instead point at the current main version.