### PR TITLE
Fix: llama.cpp server launch arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Here are recommended settings, depending on the amount of VRAM that you have:
 
   ```bash
   llama-server \
-      -hf ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF \
+      -hfr ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF \
+      --hf-file qwen2.5-coder-7b-q8_0.gguf \
       --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 \
       --ctx-size 0 --cache-reuse 256
   ```
@@ -110,7 +111,8 @@ Here are recommended settings, depending on the amount of VRAM that you have:
 
   ```bash
   llama-server \
-      -hf ggml-org/Qwen2.5-Coder-3B-Q8_0-GGUF \
+      -hfr ggml-org/Qwen2.5-Coder-3B-Q8_0-GGUF \
+      --hf-file qwen2.5-coder-3b-q8_0.gguf \
       --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 \
       --ctx-size 0 --cache-reuse 256
   ```
@@ -119,7 +121,8 @@ Here are recommended settings, depending on the amount of VRAM that you have:
 
   ```bash
   llama-server \
-      -hf ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF \
+      -hfr ggml-org/Qwen2.5-Coder-1.5B-Q8_0-GGUF \
+      --hf-file qwen2.5-coder-1.5b-q8_0.gguf \
       --port 8012 -ngl 99 -fa -ub 1024 -b 1024 -dt 0.1 \
       --ctx-size 0 --cache-reuse 256
   ```


### PR DESCRIPTION
When testing the plugin installation process, I followed the README instructions and installed llama.cpp via brew first. I discovered that the current README instructions for launching the llama.cpp server uses a `-hf` argument, which appears to be invalid. The server command fails with an error indicating `-hf` is not a recognized option. So I assume this might be a typo, or that there exists a version of `llama.cpp` that allows the short notation `-hf` instead of explicitly defining the repository via `-hfr` and then a model via `--hf-file`? However, I thought to provide a quick fix or solution for other people who want to install this, I have updated the README for all three recommended settings. I have personally tested the updated commands with all three recommended models to confirm they work as expected.

The plugin works amazingly well, thank you for this and for all the other work you have done with the llama.cpp projects!