### PR TITLE
add `:LlamaEnable`, `:LlamaDisable`, `:LlamaToggle` commands and doc

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -73,6 +73,29 @@ function! s:rand(i0, i1) abort
     return a:i0 + rand() % (a:i1 - a:i0 + 1)
 endfunction
 
+let s:llama_enabled = v:true
+
+function! llama#disable()
+    call llama#fim_cancel()
+    autocmd! llama
+    silent! iunmap <C-F>
+endfunction
+
+function! llama#toggle()
+    if s:llama_enabled
+        call llama#disable()
+    else
+        call llama#init()
+    endif
+    let s:llama_enabled = !s:llama_enabled
+endfunction
+
+function llama#setup_commands()
+    command! LlamaEnable call llama#init()
+    command! LlamaDisable call llama#disable()
+    command! LlamaToggle call llama#toggle()
+endfunction
+
 function! llama#init()
     if !executable('curl')
         echohl WarningMsg
@@ -80,6 +103,8 @@ function! llama#init()
         echohl None
         return
     endif
+
+    call llama#setup_commands()
 
     let s:pos_x = 0 " cursor position upon start of completion
     let s:pos_y = 0

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -22,6 +22,25 @@ Shortcut
 - Ctrl+F    - toggle FIM completion manually
 
 ================================================================================
+Commands
+
+*:LlamaDisable*
+
+		Disable the related autocommands and keymap for this vim/nvim session.
+		Equivalent to vimscript function: `llama#disable()`
+
+*:LlamaEnable*
+
+		Enable the related autocommands and keymap for this vim/nvim session
+		Equivalent to vimscript function: `llama#enable()`
+
+*:LlamaToggle*
+
+		Toggle the related autocommands and keymap for this vim/nvim session
+		Equivalent to vimscript function: `llama#toggle()`
+
+
+================================================================================
 How to start the server
 
 Start the llama.cpp server with a FIM-compatible model. For example:


### PR DESCRIPTION
user can then toggle the autocmd with:

```vim
:LlamaToggle
```

or do a keybinding. e.g.,

```
nnoremap <silent> <leader>lt :LlamaToggle<CR>
```

After keybinding is configurable the "[iunmap](https://github.com/ggml-org/llama.vim/compare/master...Frefreak:llama.vim:master#diff-9d64a55162097a2987d6e7c61308084f5a70744d4b49712bd57e50e8113ce4b2R81)" parts needs to be adjusted.