### PR TITLE
readme : add full name of FIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Examples:
 	let g:llama_config.show_info = v:false
 ```
 
-3. Disable auto FIM completion with lazy.nvim
+3. Disable auto FIM (Fill-In-the-Middle) completion with lazy.nvim
 ```lua
     {
         'ggml-org/llama.vim',


### PR DESCRIPTION
Expanded the first occurrence of "FIM" to "Fill-In-the-Middle" in the README for clarity.