### PR TITLE
Configurable Accept Keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Examples:
 
 4. Changing accept line keymap
 ```vim
-	let g:llama_config.accept_full_keymap = "<C-S>"
+	let g:llama_config.keymap_accept_full = "<C-S>"
 ```
 
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Examples:
     }
 ```
 
+4. Changing accept line keymap
+```vim
+	let g:llama_config.accept_full_keymap = "<C-S>"
+```
+
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)
 for the full list of options.
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -629,10 +629,9 @@ function! llama#fim_cancel()
     endif
 
     " remove the mappings
-    silent! iunmap <buffer> <Esc>
-    exe 'inoremap <buffer> ' . g:llama_config.accept_full_keymap
-    exe 'inoremap <buffer> ' . g:llama_config.accept_line_keymap
-    exe 'inoremap <buffer> ' . g:llama_config.accept_word_keymap
+    exe 'silent! iunmap <buffer> ' . g:llama_config.accept_full_keymap
+    exe 'silent! iunmap <buffer> ' . g:llama_config.accept_line_keymap
+    exe 'silent! iunmap <buffer> ' . g:llama_config.accept_word_keymap
 endfunction
 
 function! s:on_move()

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -894,9 +894,9 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
     endif
 
     " setup accept shortcuts
-    exe 'inoremap <buffer> ' . g:llama_config.accept_full_keymap . ' <C-O>:call llama#fim_accept(''full'')<CR>' 
-    exe 'inoremap <buffer> ' . g:llama_config.accept_line_keymap . ' <C-O>:call llama#fim_accept(''line'')<CR>' 
-    exe 'inoremap <buffer> ' . g:llama_config.accept_word_keymap . ' <C-O>:call llama#fim_accept(''word'')<CR>' 
+    exe 'inoremap <buffer> ' . g:llama_config.accept_full_keymap . ' <C-O>:call llama#fim_accept(''full'')<CR>'
+    exe 'inoremap <buffer> ' . g:llama_config.accept_line_keymap . ' <C-O>:call llama#fim_accept(''line'')<CR>'
+    exe 'inoremap <buffer> ' . g:llama_config.accept_word_keymap . ' <C-O>:call llama#fim_accept(''word'')<CR>'
 
     let s:hint_shown = v:true
 endfunction

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -34,22 +34,31 @@ highlight llama_hl_info guifg=#77ff2f ctermfg=119
 "   ring_scope:       the range around the cursor position (in number of lines) for gathering chunks after FIM
 "   ring_update_ms:   how often to process queued chunks in normal mode
 "
+" keymaps parameters:
+"
+"   accept_full_keymap: accept full suggestion keymap, default: <Tab>
+"   accept_line_keymap: accept line suggestion keymap, default: <S-Tab>
+"   accept_word_keymap: accept word suggestion keymap, default: <C-B>
+"
 let s:default_config = {
-    \ 'endpoint':         'http://127.0.0.1:8012/infill',
-    \ 'api_key':          '',
-    \ 'n_prefix':         256,
-    \ 'n_suffix':         64,
-    \ 'n_predict':        128,
-    \ 't_max_prompt_ms':  500,
-    \ 't_max_predict_ms': 500,
-    \ 'show_info':        2,
-    \ 'auto_fim':         v:true,
-    \ 'max_line_suffix':  8,
-    \ 'max_cache_keys':   250,
-    \ 'ring_n_chunks':    16,
-    \ 'ring_chunk_size':  64,
-    \ 'ring_scope':       1024,
-    \ 'ring_update_ms':   1000,
+    \ 'endpoint':           'http://127.0.0.1:8012/infill',
+    \ 'api_key':            '',
+    \ 'n_prefix':           256,
+    \ 'n_suffix':           64,
+    \ 'n_predict':          128,
+    \ 't_max_prompt_ms':    500,
+    \ 't_max_predict_ms':   500,
+    \ 'show_info':          2,
+    \ 'auto_fim':           v:true,
+    \ 'max_line_suffix':    8,
+    \ 'max_cache_keys':     250,
+    \ 'ring_n_chunks':      16,
+    \ 'ring_chunk_size':    64,
+    \ 'ring_scope':         1024,
+    \ 'ring_update_ms':     1000,
+    \ 'accept_full_keymap': "<Tab>",
+    \ 'accept_line_keymap': "<S-Tab>",
+    \ 'accept_word_keymap': "<C-B>",
     \ }
 
 let llama_config = get(g:, 'llama_config', s:default_config)
@@ -885,9 +894,9 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
     endif
 
     " setup accept shortcuts
-    inoremap <buffer> <Tab>   <C-O>:call llama#fim_accept('full')<CR>
-    inoremap <buffer> <S-Tab> <C-O>:call llama#fim_accept('line')<CR>
-    inoremap <buffer> <C-B>   <C-O>:call llama#fim_accept('word')<CR>
+    exe 'inoremap <buffer> ' . g:llama_config.accept_full_keymap . ' <C-O>:call llama#fim_accept(''full'')<CR>' 
+    exe 'inoremap <buffer> ' . g:llama_config.accept_line_keymap . ' <C-O>:call llama#fim_accept(''line'')<CR>' 
+    exe 'inoremap <buffer> ' . g:llama_config.accept_word_keymap . ' <C-O>:call llama#fim_accept(''word'')<CR>' 
 
     let s:hint_shown = v:true
 endfunction

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -629,9 +629,10 @@ function! llama#fim_cancel()
     endif
 
     " remove the mappings
-    silent! iunmap <buffer> <Tab>
-    silent! iunmap <buffer> <S-Tab>
     silent! iunmap <buffer> <Esc>
+    exe 'inoremap <buffer> ' . g:llama_config.accept_full_keymap
+    exe 'inoremap <buffer> ' . g:llama_config.accept_line_keymap
+    exe 'inoremap <buffer> ' . g:llama_config.accept_word_keymap
 endfunction
 
 function! s:on_move()

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -36,9 +36,9 @@ highlight llama_hl_info guifg=#77ff2f ctermfg=119
 "
 " keymaps parameters:
 "
-"   accept_full_keymap: accept full suggestion keymap, default: <Tab>
-"   accept_line_keymap: accept line suggestion keymap, default: <S-Tab>
-"   accept_word_keymap: accept word suggestion keymap, default: <C-B>
+"   keymap_accept_full: accept full suggestion keymap, default: <Tab>
+"   keymap_accept_line: accept line suggestion keymap, default: <S-Tab>
+"   keymap_accept_word: accept word suggestion keymap, default: <C-B>
 "
 let s:default_config = {
     \ 'endpoint':           'http://127.0.0.1:8012/infill',
@@ -56,9 +56,9 @@ let s:default_config = {
     \ 'ring_chunk_size':    64,
     \ 'ring_scope':         1024,
     \ 'ring_update_ms':     1000,
-    \ 'accept_full_keymap': "<Tab>",
-    \ 'accept_line_keymap': "<S-Tab>",
-    \ 'accept_word_keymap': "<C-B>",
+    \ 'keymap_accept_full': "<Tab>",
+    \ 'keymap_accept_line': "<S-Tab>",
+    \ 'keymap_accept_word': "<C-B>",
     \ }
 
 let llama_config = get(g:, 'llama_config', s:default_config)
@@ -629,9 +629,9 @@ function! llama#fim_cancel()
     endif
 
     " remove the mappings
-    exe 'silent! iunmap <buffer> ' . g:llama_config.accept_full_keymap
-    exe 'silent! iunmap <buffer> ' . g:llama_config.accept_line_keymap
-    exe 'silent! iunmap <buffer> ' . g:llama_config.accept_word_keymap
+    exe 'silent! iunmap <buffer> ' . g:llama_config.keymap_accept_full
+    exe 'silent! iunmap <buffer> ' . g:llama_config.keymap_accept_line
+    exe 'silent! iunmap <buffer> ' . g:llama_config.keymap_accept_word
 endfunction
 
 function! s:on_move()
@@ -894,9 +894,9 @@ function! s:fim_on_stdout(hash, cache, pos_x, pos_y, is_auto, job_id, data, even
     endif
 
     " setup accept shortcuts
-    exe 'inoremap <buffer> ' . g:llama_config.accept_full_keymap . ' <C-O>:call llama#fim_accept(''full'')<CR>'
-    exe 'inoremap <buffer> ' . g:llama_config.accept_line_keymap . ' <C-O>:call llama#fim_accept(''line'')<CR>'
-    exe 'inoremap <buffer> ' . g:llama_config.accept_word_keymap . ' <C-O>:call llama#fim_accept(''word'')<CR>'
+    exe 'inoremap <buffer> ' . g:llama_config.keymap_accept_full . ' <C-O>:call llama#fim_accept(''full'')<CR>'
+    exe 'inoremap <buffer> ' . g:llama_config.keymap_accept_line . ' <C-O>:call llama#fim_accept(''line'')<CR>'
+    exe 'inoremap <buffer> ' . g:llama_config.keymap_accept_word . ' <C-O>:call llama#fim_accept(''word'')<CR>'
 
     let s:hint_shown = v:true
 endfunction

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -102,7 +102,7 @@ Currently the default config is:
 		    \ 'accept_full_keymap': "<Tab>",
 		    \ 'accept_line_keymap': "<S-Tab>",
 		    \ 'accept_word_keymap': "<C-B>",
-		    \ }	
+		    \ }
 <
 
 - {endpoint}			llama.cpp server endpoint
@@ -170,18 +170,18 @@ Example:
 
 3. Disable auto FIM completion, etc (lazy.nvim, lua):
 >lua
-    {
-        'ggml-org/llama.vim',
-        init = function()
-            vim.g.llama_config = {
-                n_prefix = 1024,
-                n_suffix= 1024,
-                auto_fim = false,
-				accept_full_keymap = "<C-S>",
-            }
-        end,
-    }
-
+		{
+				'ggml-org/llama.vim',
+				init = function()
+						vim.g.llama_config = {
+								n_prefix = 1024,
+								n_suffix= 1024,
+								auto_fim = false,
+								accept_full_keymap = "<C-S>",
+						}
+				end,
+		}
+<
 To adjust the colors for hint and info texts, `llama.vim` provides the
 highlight group `llama_hl_hint` and `llama_hl_info`. You can modify these
 groups using the normal way.

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -84,22 +84,25 @@ variable.
 Currently the default config is:
 >vim
 		let s:default_config = {
-			\ 'endpoint':         'http://127.0.0.1:8012/infill',
-			\ 'api_key':          '',
-			\ 'n_prefix':         256,
-			\ 'n_suffix':         64,
-			\ 'n_predict':        128,
-			\ 't_max_prompt_ms':  500,
-			\ 't_max_predict_ms': 500,
-			\ 'show_info':        2,
-			\ 'auto_fim':         v:true,
-			\ 'max_line_suffix':  8,
-			\ 'max_cache_keys':   250,
-			\ 'ring_n_chunks':    16,
-			\ 'ring_chunk_size':  64,
-			\ 'ring_scope':       1024,
-			\ 'ring_update_ms':   1000,
-			\ }
+		    \ 'endpoint':           'http://127.0.0.1:8012/infill',
+		    \ 'api_key':            '',
+		    \ 'n_prefix':           256,
+		    \ 'n_suffix':           64,
+		    \ 'n_predict':          128,
+		    \ 't_max_prompt_ms':    500,
+		    \ 't_max_predict_ms':   500,
+		    \ 'show_info':          2,
+		    \ 'auto_fim':           v:true,
+		    \ 'max_line_suffix':    8,
+		    \ 'max_cache_keys':     250,
+		    \ 'ring_n_chunks':      16,
+		    \ 'ring_chunk_size':    64,
+		    \ 'ring_scope':         1024,
+		    \ 'ring_update_ms':     1000,
+		    \ 'accept_full_keymap': "<Tab>",
+		    \ 'accept_line_keymap': "<S-Tab>",
+		    \ 'accept_word_keymap': "<C-B>",
+		    \ }	
 <
 
 - {endpoint}			llama.cpp server endpoint
@@ -146,6 +149,13 @@ parameters for the ring-buffer with extra context:
 
 - {ring_update_ms}		how often to process queued chunks in normal mode
 
+keymaps parameters:
+
+- {accept_full_keymap}	accept full suggestion keymap, default: <Tab>
+
+- {accept_line_keymap}	accept line suggestion keymap, default: <S-Tab>
+- {accept_word_keymap}	accept word suggestion keymap, default: <C-B>
+
 Example:
 
 1. Disable the inline info (vimscript):
@@ -167,10 +177,10 @@ Example:
                 n_prefix = 1024,
                 n_suffix= 1024,
                 auto_fim = false,
+				accept_full_keymap = "<C-S>",
             }
         end,
     }
-<
 
 To adjust the colors for hint and info texts, `llama.vim` provides the
 highlight group `llama_hl_hint` and `llama_hl_info`. You can modify these

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -99,9 +99,9 @@ Currently the default config is:
 		    \ 'ring_chunk_size':    64,
 		    \ 'ring_scope':         1024,
 		    \ 'ring_update_ms':     1000,
-		    \ 'accept_full_keymap': "<Tab>",
-		    \ 'accept_line_keymap': "<S-Tab>",
-		    \ 'accept_word_keymap': "<C-B>",
+		    \ 'keymap_accept_full': "<Tab>",
+		    \ 'keymap_accept_line': "<S-Tab>",
+		    \ 'keymap_accept_word': "<C-B>",
 		    \ }
 <
 
@@ -151,10 +151,10 @@ parameters for the ring-buffer with extra context:
 
 keymaps parameters:
 
-- {accept_full_keymap}	accept full suggestion keymap, default: <Tab>
+- {keymap_accept_full}	accept full suggestion keymap, default: <Tab>
 
-- {accept_line_keymap}	accept line suggestion keymap, default: <S-Tab>
-- {accept_word_keymap}	accept word suggestion keymap, default: <C-B>
+- {keymap_accept_line}	accept line suggestion keymap, default: <S-Tab>
+- {keymap_accept_word}	accept word suggestion keymap, default: <C-B>
 
 Example:
 
@@ -177,7 +177,7 @@ Example:
 								n_prefix = 1024,
 								n_suffix= 1024,
 								auto_fim = false,
-								accept_full_keymap = "<C-S>",
+								keymap_accept_full = "<C-S>",
 						}
 				end,
 		}


### PR DESCRIPTION
I tried to make the key maps configurable using the g:llama_config object, the default key binds are the same

this is my first time working with vimscript, so I have no idea how bad this pr code is, if there is a better way to do this or if this is "good enough", that said any feedback or improvement is appreciated

this pr should address the issue #34