### PR TITLE
Allow configuration of the "stop" key in the request, allowing us to force single-line completions.

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -10,6 +10,7 @@ highlight llama_hl_info guifg=#77ff2f ctermfg=119
 "   n_prefix:         number of lines before the cursor location to include in the local prefix
 "   n_suffix:         number of lines after  the cursor location to include in the local suffix
 "   n_predict:        max number of tokens to predict
+"   stop_strings      return the result immediately as soon as any of these strings are encountered in the generated text
 "   t_max_prompt_ms:  max alloted time for the prompt processing (TODO: not yet supported)
 "   t_max_predict_ms: max alloted time for the prediction
 "   show_info:        show extra info about the inference (0 - disabled, 1 - statusline, 2 - inline)
@@ -47,6 +48,7 @@ let s:default_config = {
     \ 'n_prefix':           256,
     \ 'n_suffix':           64,
     \ 'n_predict':          128,
+    \ 'stop_strings':       [],
     \ 't_max_prompt_ms':    500,
     \ 't_max_predict_ms':   1000,
     \ 'show_info':          2,
@@ -585,6 +587,7 @@ function! llama#fim(pos_x, pos_y, is_auto, prev, use_cache) abort
         \ 'input_extra':      l:extra_ctx,
         \ 'prompt':           l:middle,
         \ 'n_predict':        g:llama_config.n_predict,
+        \ 'stop':             g:llama_config.stop_strings,
         \ 'n_indent':         l:indent,
         \ 'top_k':            40,
         \ 'top_p':            0.90,

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -190,6 +190,21 @@ Example:
 			end,
 		}
 <
+4. Force single-line FIM completion (lazy.nvim, lua):
+>lua
+		{
+			'ggml-org/llama.vim',
+			init = function()
+				vim.g.llama_config = {
+					n_prefix = 1024,
+					n_suffix= 1024,
+					auto_fim = false,
+					keymap_accept_full = "<C-S>",
+					stop_strings = { "\n" },
+				}
+			end,
+		}
+<
 To adjust the colors for hint and info texts, `llama.vim` provides the
 highlight group `llama_hl_hint` and `llama_hl_info`. You can modify these
 groups using the normal way.

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -197,7 +197,7 @@ Example:
 			init = function()
 				vim.g.llama_config = {
 					n_prefix = 1024,
-					n_suffix= 1024,
+					n_suffix = 1024,
 					auto_fim = false,
 					keymap_accept_full = "<C-S>",
 					stop_strings = { "\n" },

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -89,6 +89,7 @@ Currently the default config is:
 		    \ 'n_prefix':           256,
 		    \ 'n_suffix':           64,
 		    \ 'n_predict':          128,
+		    \ 'stop_strings':       [],
 		    \ 't_max_prompt_ms':    500,
 		    \ 't_max_predict_ms':   500,
 		    \ 'show_info':          2,
@@ -117,6 +118,9 @@ Currently the default config is:
 						in the local suffix
 
 - {n_predict}			max number of tokens to predict
+
+- {stop_strings}		return the result immediately as soon as any of these
+						strings are encountered in the generated text
 
 - {t_max_prompt_ms}		max alloted time for the prompt processing
 						(TODO: not yet supported)


### PR DESCRIPTION
I've been using a hardcoded version of this for a few months. Since I run qwen2.5-coder-1.5B on my low end 3050TI (laptop), forcing single-line completions has greatly improved the response time to be near instantaneous.