### PR TITLE
Enable easier overriding highlights in rc files

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sts=4 expandtab
 " colors (adjust to your liking)
-highlight llama_hl_hint guifg=#ff772f ctermfg=202
-highlight llama_hl_info guifg=#77ff2f ctermfg=119
+highlight default llama_hl_hint guifg=#ff772f ctermfg=202
+highlight default llama_hl_info guifg=#77ff2f ctermfg=119
 
 " general parameters:
 "


### PR DESCRIPTION
Marking the highlights as `default` allows them to be overridden by a preceding definition, such as in rc files, which I think the plugin usually gets loaded after. Otherwise, the user either has to use an autocommand, or else edit the plugin file directly (which may conflict when a plugin manager wants to update it).

Without this, the code example included in the project documentation doesn't seem to work as intended if inserted directly into rc files.

Otherwise, as per the docs on `:hi-default` for vim and neovim, this should be equivalent.