### PR TITLE
Fix display of completion on wrapped lines

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -958,9 +958,9 @@ function! s:fim_render(pos_x, pos_y, data)
 
     " display the suggestion and append the info to the end of the first line
     if s:ghost_text_nvim
-        call nvim_buf_set_extmark(l:bufnr, l:id_vt_fim, l:pos_y - 1, l:pos_x - 1, {
+        call nvim_buf_set_extmark(l:bufnr, l:id_vt_fim, l:pos_y - 1, l:pos_x, {
             \ 'virt_text': [[l:content[0], 'llama_hl_hint'], [l:info, 'llama_hl_info']],
-            \ 'virt_text_win_col': virtcol('.') - 1
+            \ 'virt_text_pos': l:content == [""] ? 'eol' : 'overlay'
             \ })
 
         call nvim_buf_set_extmark(l:bufnr, l:id_vt_fim, l:pos_y - 1, 0, {

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -964,8 +964,7 @@ function! s:fim_render(pos_x, pos_y, data)
             \ })
 
         call nvim_buf_set_extmark(l:bufnr, l:id_vt_fim, l:pos_y - 1, 0, {
-            \ 'virt_lines': map(l:content[1:], {idx, val -> [[val, 'llama_hl_hint']]}),
-            \ 'virt_text_win_col': virtcol('.')
+            \ 'virt_lines': map(l:content[1:], {idx, val -> [[val, 'llama_hl_hint']]})
             \ })
     elseif s:ghost_text_vim
         let l:full_suffix = l:content[0]


### PR DESCRIPTION
This partially resolves #69, allowing the completion to display on the current line of the cursor in soft-wrapped text.

Previously, `l:pos_x` gave the completion roughly correct position, but then using `virt_text_win_col` to nudge it a little prevented display with the cursor on anything but the first screen-line of a wrapped line, since the `virtcol('.')` function does not respect wrapping, nor does any other nvim api function, at least not in the way that is needed, other functions have problems if you set `number` and so on.

Basically, we used to draw it offscreen in the described case, in a column past the edge of the screen, and that way of positioning seems hard to fix.

We could add all sorts of logic for number and sign columns, but it seems easier and _seems_ to work to just to nudge the mark right by one, then position using `virt_text_pos`, using `overlay` by default to overwrite the text currently on the line which the code will replace anyway, or `eol` if there's no actual completion so that the generation info of blank output doesn't uselessly overwrite the text on screen.

Note that this won't clear the suffix of a line that might become cleared in a multiline completion, it will just draw the completion info over the top, so the old text might peek out underneath if it's longer. But then neither did the old code afaict, so this _should_ behave the same.

Please note that I have not extensively tested this, just the obvious checks that I can do, so someone who knows better than me should probably have a check before this is merged, but it works for me and I see no reason why this shouldn't be correct.

This also still doesn't allow wrapping the completion. As a future enhancement not covered in this pull request, I think we could switch to `inline` to get the completion itself to wrap, in the limited case where there's one line of content and an empty `l:line_cur_suffix` (cursor at end of line). This would nudge the proceeding code about on the user's screen and so this should be optional for users who restrict completion to a single line, which is why I've left that out for now. But I'd probably optionally precede the condition with `l:line_cur_suffix == "" ? 'inline' : ...`.

Note that I also removed the `virt_text_win_col` parameter from the code that deals with the subsequent lines, as that parameter seems redundant because it renders as virt_lines rather than virt_text. Someone correct me if I'm wrong.