### PR TITLE
Add pattern match to reduce suffix duplication

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -914,7 +914,13 @@ function! s:fim_render(pos_x, pos_y, data)
     "    endif
     "endfor
 
-    let l:content[-1] .= l:line_cur_suffix
+    " only add suffix if not already there to workaround confused llms,
+    " only match if word chars are in the suffix to avoid miscounting brackets
+    " or other important punctuation from correct llm output,
+    " may need tweaking if a bad pattern comes up
+    if !(l:content[-1] =~# '\V' . escape(l:line_cur_suffix, '/\') . '\$' && l:line_cur_suffix =~# '\w\w' )
+        let l:content[-1] .= l:line_cur_suffix
+    endif
 
     " if only whitespaces - do not accept
     if join(l:content, "\n") =~? '^\s*$'


### PR DESCRIPTION
A perfect LLM wouldn't need this, because it would understand the suffix is already there and that this project's code will append it anyway. But real LLMs aren't perfect, so if the suffix is already there in the last line then we should avoid appending it again, particularly in multi-line suggestions.

However, the suffix could be a closing bracket and the completion could add a function call _ending_ in a closing bracket or other punctuation, so to avoid messing up otherwise perfect completions we only use this in the event

If anyone else has opinions on what should determine if the suffix is that kind of punctuation or not then feel free to tweak this, but for now I just check for two consecutive word characters, that may need tweaking if it causes issues for a particular programming language or something like that.

Also would be very grateful if someone had a check of my use of `escape()` in the pattern matching. This _should_ be safe, due to the use of very magic pattern matching (`\V`), and even failing that the regex shouldn't be able to do anything nasty anyway, but I still feel a little uneasy passing in arbitrary data here, given my lack of experience writing this kind of code before. 