### PR TITLE
Fix typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Demonstrates that the global context is accumulated and maintained across differ
 
 The plugin aims to be very simple and lightweight and at the same time to provide high-quality and performant local FIM completions, even on consumer-grade hardware. Read more on how this is achieved in the following links:
 
-- Initial implementation and techincal description: https://github.com/ggml-org/llama.cpp/pull/9787
+- Initial implementation and technical description: https://github.com/ggml-org/llama.cpp/pull/9787
 - Classic Vim support: https://github.com/ggml-org/llama.cpp/pull/9995
 
 ## Other IDEs


### PR DESCRIPTION
A simple typo fix, which I noticed while reading the readme.