### PR TITLE
check FIM response for expected format

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -685,6 +685,16 @@ function! s:fim_on_response(hashes, job_id, data, event = v:null)
         return
     endif
 
+    " ensure the response is valid JSON, starting with a fast check before full decode
+    if l:raw !~# '^\s*{' || l:raw !~# '\v"content"\s*:"'
+        return
+    endif
+    try
+        let l:response = json_decode(l:raw)
+    catch
+        return
+    endtry
+
     " put the response in the cache
     for l:hash in a:hashes
         call s:cache_insert(l:hash, l:raw)


### PR DESCRIPTION
Partially fixes #61 by handling errors gracefully (though it will not help users discover that their entire server is set up incorrectly). ~~Also does not explain why llama-server sometimes has `sequence 0 does not start from the last position stored in the memory` errors.~~ But, it does handle unexpected server responses gracefully.

This approach handles unexpected issues upon server response in `fim_on_response`, avoiding taking up slots in the cache with invalid responses. You can test it with a couple of examples by entering these commands:

## Not valid JSON (endpoint returns HTML)
```
:let g:llama_config['endpoint'] = 'https://example.com'
```

## Valid JSON missing the `content` key
```
:let g:llama_config['endpoint'] = 'https://dummyjson.com/posts/add'
```

It might be overkill to check the JSON string before decoding, I was just worried about small performance hits from unnecessarily doing full JSON decodes, especially since this can happen on every keypress if the responses are invalid, since there will never be cache hits.