### PR TITLE
core: enable llama_enabled in init(), disable in disable()

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -68,7 +68,7 @@ let s:default_config = {
 let llama_config = get(g:, 'llama_config', s:default_config)
 let g:llama_config = extendnew(s:default_config, llama_config, 'force')
 
-let s:llama_enabled = v:true
+let s:llama_enabled = v:false
 
 " containes cached responses from the server
 " used to avoid re-computing the same completions and to also create new completions with similar context
@@ -108,6 +108,7 @@ function! llama#disable()
     call llama#fim_hide()
     autocmd! llama
     exe "silent! iunmap " .. g:llama_config.keymap_trigger
+    let s:llama_enabled = v:false
 endfunction
 
 function! llama#toggle()
@@ -116,7 +117,6 @@ function! llama#toggle()
     else
         call llama#init()
     endif
-    let s:llama_enabled = !s:llama_enabled
 endfunction
 
 function llama#setup_commands()
@@ -200,6 +200,8 @@ function! llama#init()
     if g:llama_config.ring_n_chunks > 0
         call s:ring_update()
     endif
+
+    let s:llama_enabled = v:true
 endfunction
 
 " compute how similar two chunks of text are


### PR DESCRIPTION
I disabled llama.vim by default with a Lazy lua config function:
```
    config = function()
      -- Defer LlamaDisable until plugin commands are available
      vim.defer_fn(function()
        -- Call disable function to remove mappings and autocommands
        vim.fn['llama#disable']()
      end, 100) -- Delay by 100ms to ensure plugin is loaded
    end,
```
Doing so, I had to toggle the plugin twice to enable it, of course this should only be necessary once (off->on).

Looking at the code, a better way to do this would be to consistently set the enabled flag at the end of the init() and disable() functions instead.

Initializing llama_enabled default-false is just so the variable comes into existence at all, it will immediately be overwritten by the init function (to true) anyways.
Behavior should not change besides fixing the bug where neither `:LlamaEnable` nor `:LlamaDisable` internally modify the variable, impeding consistency of `:LlamaToggle` functionality.