### PR TITLE
core: add enable_at_startup option

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -17,6 +17,7 @@ highlight default llama_hl_info guifg=#77ff2f ctermfg=119
 "   auto_fim:         trigger FIM completion automatically on cursor movement
 "   max_line_suffix:  do not auto-trigger FIM completion if there are more than this number of characters to the right of the cursor
 "   max_cache_keys:   max number of cached completions to keep in result_cache
+"   enable_at_startup: enable llama.vim functionality at startup (default: v:true)
 "
 " ring buffer of chunks, accumulated with time upon:
 "
@@ -63,6 +64,7 @@ let s:default_config = {
     \ 'keymap_accept_full': "<Tab>",
     \ 'keymap_accept_line': "<S-Tab>",
     \ 'keymap_accept_word': "<C-B>",
+    \ 'enable_at_startup':  v:true,
     \ }
 
 let llama_config = get(g:, 'llama_config', s:default_config)
@@ -132,6 +134,9 @@ function! llama#disable()
     call llama#fim_hide()
     autocmd! llama
     exe "silent! iunmap " .. g:llama_config.keymap_trigger
+    exe "silent! iunmap <buffer> " .. g:llama_config.keymap_accept_full
+    exe "silent! iunmap <buffer> " .. g:llama_config.keymap_accept_line
+    exe "silent! iunmap <buffer> " .. g:llama_config.keymap_accept_word
     let s:llama_enabled = v:false
 endfunction
 
@@ -139,12 +144,12 @@ function! llama#toggle()
     if s:llama_enabled
         call llama#disable()
     else
-        call llama#init()
+        call llama#enable()
     endif
 endfunction
 
-function llama#setup_commands()
-    command! LlamaEnable  call llama#init()
+function! llama#setup_commands()
+    command! LlamaEnable  call llama#enable()
     command! LlamaDisable call llama#disable()
     command! LlamaToggle  call llama#toggle()
 endfunction
@@ -190,6 +195,16 @@ function! llama#init()
         if empty(prop_type_get(s:hlgroup_info))
             call prop_type_add(s:hlgroup_info, {'highlight': s:hlgroup_info})
         endif
+    endif
+
+    if g:llama_config.enable_at_startup
+        call llama#enable()
+    endif
+endfunction
+
+function! llama#enable()
+    if s:llama_enabled
+        return
     endif
 
     augroup llama

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -104,6 +104,7 @@ Currently the default config is:
 		    \ 'keymap_accept_full': "<Tab>",
 		    \ 'keymap_accept_line': "<S-Tab>",
 		    \ 'keymap_accept_word': "<C-B>",
+		    \ 'enable_at_startup':  v:true,
 		    \ }
 <
 
@@ -138,6 +139,8 @@ Currently the default config is:
 
 - {max_cache_keys}		max number of cached completions to keep in result_cache
 
+- {enable_at_startup}	whether to enable llama.vim functionality at startup
+						(v:true to enable, v:false to disable; default: v:true)
 
 parameters for the ring-buffer with extra context:
 
@@ -186,6 +189,7 @@ Example:
 					n_suffix= 1024,
 					auto_fim = false,
 					keymap_accept_full = "<C-S>",
+					enable_at_startup = false,
 				}
 			end,
 		}
@@ -201,6 +205,7 @@ Example:
 					auto_fim = false,
 					keymap_accept_full = "<C-S>",
 					stop_strings = { "\n" },
+					enable_at_startup = false,
 				}
 			end,
 		}


### PR DESCRIPTION
As mentioned in a [previous pull request](https://github.com/ggml-org/llama.vim/pull/77), until now, llama.vim was default-enabled with no parameter to disable it at startup, which I want:
I don't need every nvim instance to run infill.

Previously, I had to manually run `:LlamaDisable` after startup, which was a bit of a pain.

```
    config = function()
      -- Defer LlamaDisable until plugin commands are available
      vim.defer_fn(function()
        -- Call disable function to remove mappings and autocommands
        vim.fn['llama#disable']()
      end, 100) -- Delay by 100ms to ensure plugin is loaded
    end,

```

Thanks for the go-ahead to propose this feature!

I've added a new option `enable_at_startup` which is default-enabled so as not to modify the existing behavior, but can be set to false to disable it at startup.

To do so, I've separated `lama#init()` into `llama#init()` and `llama#enable()`, the former calls the latter if enable_at_startup is true.

Unrelated bonus: llama#disable() now also unbinds the keymaps, they aren't necessary when disabled.

I hope these changes are acceptable :)
