### PR TITLE
Implement function to check hint visibility

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1139,3 +1139,7 @@ function! llama#fim_hide()
     exe 'silent! iunmap <buffer> ' . g:llama_config.keymap_accept_line
     exe 'silent! iunmap <buffer> ' . g:llama_config.keymap_accept_word
 endfunction
+
+function! llama#is_hint_shown()
+    return s:hint_shown
+endfunction


### PR DESCRIPTION
Add function to check if hint is shown in llama.
Example with [blink.cmp](https://github.com/Saghen/blink.cmp):
```lua
      ---@module 'blink.cmp'
      ---@type blink.cmp.Config
      return {
        keymap = {
          preset = "none",
          ["<Tab>"] = {
            function(cmp)
              if vim.fn["llama#is_hint_shown"]() then
                vim.schedule(function()
                  vim.fn["llama#fim_accept"] "full"
                end)
                return true
              end
              if cmp.is_visible() then
                return cmp.select_next()
              else
                return cmp.select_and_accept()
              end
            end,
            "fallback",
          },
        },
      }
```