### PR TITLE
misc: add `LlamaToggleAutoFim` command

### DIFF
--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -39,6 +39,10 @@ Commands
 		Toggle the related autocommands and keymap for this vim/nvim session
 		Equivalent to vimscript function: `llama#toggle()`
 
+*:LlamaToggleAutoFim*
+
+		Toggle autofim for this vim/nvim session
+		Equivalent to vimscript function: `llama#toggle_auto_fim()`
 
 ================================================================================
 How to start the server


### PR DESCRIPTION
The old way to call `init` does not work anymore as we don't get a chance to re-init the autocmd.