### PR TITLE
adjust cursor placement for single-line completion

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1209,7 +1209,7 @@ function! llama#fim_accept(accept_type)
             call cursor(l:pos_y, l:pos_x + len(l:word) + 1)
         elseif a:accept_type == 'line' || len(l:content) == 1
             " move cursor for 1-line suggestion
-            call cursor(l:pos_y, l:pos_x + len(l:content[0]) + 1)
+            call cursor(l:pos_y, l:pos_x + len(l:content[0]))
             if len(l:content) > 2
                 " simulate pressing Enter to move to next line
                 call feedkeys("\<CR>")


### PR DESCRIPTION
When completing single lines (shift+tab) without a stop character configured, an extra line was being added due to an off-by-one error.

`l:pos_x` is zero-based so adding an extra `1` causes the cursor to be placed one character past the end of the completion (on the next line).