### PR TITLE
Bring back fim_hint_shown

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1307,6 +1307,7 @@ function! llama#fim_hide()
     endif
 endfunction
 
+" ref: https://github.com/ggml-org/llama.vim/pull/85
 function! llama#is_fim_hint_shown()
     return s:fim_hint_shown
 endfunction


### PR DESCRIPTION
The #96 removed the is_hint_shown function, which was added in #85. This PR brings it back and rename it to is_fim_hint_shown.