### PR TITLE
core : add :Llama subcommand interface

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -245,7 +245,39 @@ function! llama#toggle_auto_fim()
     call llama#setup_autocmds()
 endfunction
 
+function! llama#command(line1, line2, subcommand) abort
+    if a:subcommand ==# 'enable'
+        call llama#enable()
+    elseif a:subcommand ==# 'disable'
+        call llama#disable()
+    elseif a:subcommand ==# 'toggle'
+        call llama#toggle()
+    elseif a:subcommand ==# 'toggle-auto-fim'
+        call llama#toggle_auto_fim()
+    elseif a:subcommand ==# 'debug-toggle'
+        call llama#debug_toggle()
+    elseif a:subcommand ==# 'debug-clear'
+        call llama#debug_clear()
+    elseif a:subcommand ==# 'instruct'
+        call llama#inst(a:line1, a:line2)
+    else
+        echohl ErrorMsg
+        echo 'Unknown Llama subcommand: ' . a:subcommand
+        echohl None
+    endif
+endfunction
+
+" Tab completion options for :Llama command.
+function! llama#completions(arg_lead, _cmd_line, _cursor_pos) abort
+    let l:options = ['enable', 'disable', 'toggle', 'toggle-auto-fim', 'debug-toggle', 'debug-clear', 'instruct']
+    " Filter options that start with what the user typed
+    return filter(copy(l:options), 'v:val =~# "^" . a:arg_lead')
+endfunction
+
 function! llama#setup()
+    " Define :Llama command with tab completion and range support.
+    command! -range=% -nargs=1 -complete=customlist,llama#completions Llama call llama#command(<line1>, <line2>, <q-args>)
+
     command! LlamaEnable         call llama#enable()
     command! LlamaDisable        call llama#disable()
     command! LlamaToggle         call llama#toggle()

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -255,9 +255,9 @@ function! llama#command(line1, line2, subcommand) abort
     elseif a:subcommand ==# 'toggle-auto-fim'
         call llama#toggle_auto_fim()
     elseif a:subcommand ==# 'debug-toggle'
-        call llama#debug_toggle()
+        call llama_debug#toggle()
     elseif a:subcommand ==# 'debug-clear'
-        call llama#debug_clear()
+        call llama_debug#clear()
     elseif a:subcommand ==# 'instruct'
         call llama#inst(a:line1, a:line2)
     else
@@ -277,13 +277,6 @@ endfunction
 function! llama#setup()
     " Define :Llama command with tab completion and range support.
     command! -range=% -nargs=1 -complete=customlist,llama#completions Llama call llama#command(<line1>, <line2>, <q-args>)
-
-    command! LlamaEnable         call llama#enable()
-    command! LlamaDisable        call llama#disable()
-    command! LlamaToggle         call llama#toggle()
-    command! LlamaToggleAutoFim  call llama#toggle_auto_fim()
-
-    command! -range=% LlamaInstruct call llama#inst(<line1>, <line2>)
 
     call llama#debug_setup()
 endfunction

--- a/autoload/llama_debug.vim
+++ b/autoload/llama_debug.vim
@@ -133,7 +133,4 @@ endfunction
 
 function! llama_debug#setup() abort
     call llama_debug#clear()
-
-    command! LlamaDebugClear  call llama_debug#clear()
-    command! LlamaDebugToggle call llama_debug#toggle()
 endfunction


### PR DESCRIPTION
This commit add a suggestion to introduce a Llama subcommand interface. 
This is very much a personal preference and is similar to how the Copilot plugin works.

Example usage:
```console
:Llama <tab>
```
It is possible to start typing and get completions for the subcommands that begin with the typed prefix.