### PR TITLE
Support custom request params

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -30,6 +30,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   auto_fim:         trigger FIM completion automatically on cursor movement
 "   max_line_suffix:  do not auto-trigger FIM completion if there are more than this number of characters to the right of the cursor
 "   max_cache_keys:   max number of cached completions to keep in result_cache
+"   fim_params:       request parameters for the FIM completion (optional, use default parameters if not provided)
+"   inst_params:      request parameters for the instruction completion (optional, use default parameters if not provided)
 "   enable_at_startup: enable llama.vim functionality at startup (default: v:true)
 "
 " ring buffer of chunks, accumulated with time upon:
@@ -92,6 +94,8 @@ let s:default_config = {
     \ 'keymap_inst_accept':     "<Tab>",
     \ 'keymap_inst_cancel':     "<Esc>",
     \ 'keymap_debug_toggle':    "<leader>lld",
+    \ 'fim_params':             {},
+    \ 'inst_params':            {},
     \ 'enable_at_startup':      v:true,
     \ }
 
@@ -823,6 +827,7 @@ function! llama#fim(pos_x, pos_y, is_auto, prev, use_cache) abort
         \                       "tokens_cached",
         \                     ],
         \ }
+    call extend(l:request, g:llama_config.fim_params, 'force')
 
     let l:curl_command = [
         \ "curl",
@@ -1497,6 +1502,7 @@ function! llama#inst_send(req_id, messages)
         \ 'stream':       v:true,
         \ 'cache_prompt': v:true,
         \ }
+    call extend(l:request, g:llama_config.inst_params, 'force')
 
     let l:curl_command = [
         \ "curl",

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -134,6 +134,8 @@ Currently the default config is:
 		    \ 'keymap_inst_accept':     "<Tab>",
 		    \ 'keymap_inst_cancel':     "<Esc>",
 		    \ 'keymap_debug_toggle':    "<leader>lld",
+            \ 'fim_params':             {},
+            \ 'inst_params':            {},
 		    \ 'enable_at_startup':      v:true,
 		    \ }
 <
@@ -176,6 +178,12 @@ Currently the default config is:
 						of the cursor
 
 - {max_cache_keys}		max number of cached completions to keep in result_cache
+
+- {fim_params}		    request parameters for the FIM completion (optional, use
+                        default parameters if not provided)
+
+- {inst_params}		    request parameters for the instruction completion
+                        (optional, use default parameters if not provided)
 
 - {enable_at_startup}	whether to enable llama.vim functionality at startup
 						(v:true to enable, v:false to disable; default: v:true)


### PR DESCRIPTION
# Issue Description

I'm using this plugin along with qwen3.5, and I want to serve 1 model to handle both fim and chat tasks.

For fim tasks, I want to set repeat-penalty to `1.0`, and for chat tasks I want to set it to `1.05`. Since the built in web page of llama-server doesn't seem to support custom params, so I need to pass `--repeat-penalty to 1.05` to llama-server. But if I do so, I cannot use `repeat-penalty=1.0` in llama.vim since this plugin doesn't provide any method to allow users set custom request params.

# The Solution

This PR adds 2 config options: `fim_params` and `inst_params`. Users can set custom request params via these options. I use `extend(..., 'force')` so user's config is always prior to the default params.