### PR TITLE
Configuration option to disable for filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Examples:
     all filetypes, then further only enabled it for specific filetypes. eg:
 
     ```vim
-    let g:llama_config = { 'disabled_filetypes': [''], 'enabled_filetypes': ['rust']  }
+    let g:llama_config = { 'disabled_filetypes': ['*'], 'enabled_filetypes': ['rust']  }
     ```
 
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ Examples:
     let g:llama_config.keymap_inst_cancel   = "<Esc>"
     ```
 
+6. Disable code completion for certain filetypes (e.g., markdown)
+
+    ```vim
+    let g:llama_config = { 'disable_filetypes': ['markdown', 'text'] }
+    ```
+
+    Or with lazy.nvim:
+
+    ```lua
+    {
+        'ggml-org/llama.vim',
+        init = function()
+            vim.g.llama_config = {
+                disable_filetypes = { 'markdown', 'text'},
+            }
+        end,
+    }
+    ```
+
+    This will prevent the plugin from enabling when the filetype matches any
+    of the entries in the `disable_filetypes` list.
+
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)
 for the full list of options.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Examples:
 6. Disable code completion for certain filetypes (e.g., markdown)
 
     ```vim
-    let g:llama_config = { 'disable_filetypes': ['markdown', 'text'] }
+    let g:llama_config = { 'disabled_filetypes': ['markdown', 'text'] }
     ```
 
     Or with lazy.nvim:
@@ -119,14 +119,21 @@ Examples:
         'ggml-org/llama.vim',
         init = function()
             vim.g.llama_config = {
-                disable_filetypes = { 'markdown', 'text'},
+                disabled_filetypes = { 'markdown', 'text'},
             }
         end,
     }
     ```
 
     This will prevent the plugin from enabling when the filetype matches any
-    of the entries in the `disable_filetypes` list.
+    of the entries in the `disabled_filetypes` list. 
+
+    Additionally, using `enabled_filetypes` one can disable code completion for
+    all filetypes, then further only enabled it for specific filetypes. eg:
+
+    ```vim
+    let g:llama_config = { 'disabled_filetypes': [''], 'enabled_filetypes': ['rust']  }
+    ```
 
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)
 for the full list of options.

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -390,7 +390,7 @@ endfunction
 function! llama#enable()
     " check if current filetype is in disabled_filetypes list
     let l:current_ft = &filetype
-    if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) >= -1
+    if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
         call llama#debug_log('plugin not enabled for filetype: ' . l:current_ft)
         return
     endif

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -206,9 +206,7 @@ function! s:check_filetype()
 
     if l:is_disabled && !l:is_enabled
         " filetype is disabled, disabled plugin
-            call llama#debug_log('1')
         if s:llama_enabled
-            call llama#debug_log('about to disable')
             call llama#disable()
 
             " now that llama is disabled the autocmd group will not be called
@@ -217,13 +215,10 @@ function! s:check_filetype()
             " NOTE because of this, if the user disables the plugin manually, 
             " This filetype check will not be performed until the user
             " manually re-enables the plugin. 
-            augroup llama_filetype_check
-                autocmd BufEnter * call s:check_filetype()
-            augroup END
+            call llama#setup_filetype_check_autocmds()
         endif
     else
         if !s:llama_enabled
-            call llama#debug_log('about to enable')
             call llama#enable()
         endif
     endif
@@ -233,7 +228,7 @@ function! llama#disable()
     call llama#fim_hide()
 
     autocmd! llama
-    autocmd! llama_filetype_check
+    silent! autocmd! llama_filetype_check
 
     " TODO: these unmaps don't seem to work properly
     if g:llama_config.keymap_fim_trigger != ''
@@ -392,9 +387,12 @@ function! llama#setup_autocmds()
 
         " gather chunk upon saving the file
         autocmd BufWritePost    * call s:pick_chunk(getline(max([1, line('.') - g:llama_config.ring_chunk_size/2]), min([line('.') + g:llama_config.ring_chunk_size/2, line('$')])), v:true, v:true)
+    augroup END
+endfunction
 
-        " check filetype on buffer enter and enable/disable accordingly
-        autocmd BufEnter        * call s:check_filetype()
+function! llama#setup_filetype_check_autocmds()
+    augroup llama
+        autocmd BufEnter * call s:check_filetype()
     augroup END
 endfunction
 
@@ -403,9 +401,7 @@ function! llama#enable()
     let l:current_ft = &filetype
     if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
         call llama#debug_log('plugin not enabled for filetype: ' . l:current_ft)
-        augroup llama_filetype_check
-            autocmd BufEnter * call s:check_filetype()
-        augroup END
+        call llama#setup_filetype_check_autocmds()
         return
     endif
 
@@ -438,6 +434,7 @@ function! llama#enable()
     endif
 
     call llama#setup_autocmds()
+    call llama#setup_filetype_check_autocmds()
 
     silent! call llama#fim_hide()
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -191,23 +191,25 @@ endfunction
 function! s:check_filetype()
     let l:current_ft = &filetype
 
-    "" skip if not in a listed buffer
-    "if !buflisted(bufnr('%'))
-    "    return
-    "endif
-    
     " skip if not in a real buffer
     if !buflisted(bufnr('%')) || !filereadable(expand('%'))
         return
     endif
 
     if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
-        " filetype is disabled, ensure plugin is disabled
+        " filetype is disabled, disabled plugin
         if s:llama_enabled
             call llama#disable()
+
+            " now that llama is disabled the autocmd group will not be called
+            " so we must re-add in the check_filetype autocmd 
+            "
+            " NOTE because of this, if the user disables the plugin manually, 
+            " This filetype check will not be performed until the user
+            " manually re-enables the plugin. 
+            autocmd BufEnter        * call s:check_filetype()
         endif
     else
-        " filetype is not disabled, ensure plugin is enabled (if not already)
         if !s:llama_enabled
             call llama#enable()
         endif
@@ -218,10 +220,6 @@ function! llama#disable()
     call llama#fim_hide()
 
     autocmd! llama
-
-    " only remove autocmds that are active when plugin is enabled
-    " keep BufEnter for filetype checking so plugin can re-enable
-    autocmd BufEnter        * call s:check_filetype()
 
     " TODO: these unmaps don't seem to work properly
     if g:llama_config.keymap_fim_trigger != ''

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -191,8 +191,8 @@ endfunction
 function! s:check_filetype()
     let l:current_ft = &filetype
 
-    " skip if not in a real buffer
-    if !buflisted(bufnr('%')) || !filereadable(expand('%'))
+    " skip if not in a listed buffer
+    if !buflisted(bufnr('%'))
         return
     endif
 
@@ -378,14 +378,14 @@ function! llama#setup_autocmds()
 endfunction
 
 function! llama#enable()
-    if s:llama_enabled
-        return
-    endif
-
     " check if current filetype is in disable_filetypes list
     let l:current_ft = &filetype
     if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
         call llama#debug_log('plugin not enabled for filetype: ' . l:current_ft)
+        return
+    endif
+
+    if s:llama_enabled
         return
     endif
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -31,6 +31,9 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   max_line_suffix:  do not auto-trigger FIM completion if there are more than this number of characters to the right of the cursor
 "   max_cache_keys:   max number of cached completions to keep in result_cache
 "   enable_at_startup: enable llama.vim functionality at startup (default: v:true)
+"   disabled_filetypes: list of filetypes to disable code completion (default: [])
+"   enable_filetypes:   list of filetypes to enable code completion (default: [])
+"                       overrides disabled filetypes, useful if used with disabled_filetypes = [""] 
 "
 " ring buffer of chunks, accumulated with time upon:
 "
@@ -49,7 +52,6 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   ring_scope:       the range around the cursor position (in number of lines) for gathering chunks after FIM
 "   ring_update_ms:   how often to process queued chunks in normal mode
 "
-"   disable_filetypes: list of filetypes to disable code completion (default: [])
 "
 " keymaps parameters (empty string to disable):
 "
@@ -95,7 +97,8 @@ let s:default_config = {
     \ 'keymap_inst_cancel':     "<Esc>",
     \ 'keymap_debug_toggle':    "<leader>lld",
     \ 'enable_at_startup':      v:true,
-    \ 'disable_filetypes':      [],
+    \ 'disabled_filetypes':      [],
+    \ 'enabled_filetypes':      [],
     \ }
 
 let llama_config = get(g:, 'llama_config', s:default_config)
@@ -187,7 +190,7 @@ function! s:rand(i0, i1) abort
     return a:i0 + rand() % (a:i1 - a:i0 + 1)
 endfunction
 
-" check if current filetype is in disable_filetypes list and enable/disable accordingly
+" check if current filetype is in disabled_filetypes list and enable/disable accordingly
 function! s:check_filetype()
     let l:current_ft = &filetype
 
@@ -196,7 +199,7 @@ function! s:check_filetype()
         return
     endif
 
-    if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
+    if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
         " filetype is disabled, disabled plugin
         if s:llama_enabled
             call llama#disable()
@@ -385,9 +388,9 @@ function! llama#setup_autocmds()
 endfunction
 
 function! llama#enable()
-    " check if current filetype is in disable_filetypes list
+    " check if current filetype is in disabled_filetypes list
     let l:current_ft = &filetype
-    if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
+    if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) >= -1
         call llama#debug_log('plugin not enabled for filetype: ' . l:current_ft)
         return
     endif

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -49,6 +49,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   ring_scope:       the range around the cursor position (in number of lines) for gathering chunks after FIM
 "   ring_update_ms:   how often to process queued chunks in normal mode
 "
+"   disable_filetypes: list of filetypes to disable code completion (default: [])
+"
 " keymaps parameters (empty string to disable):
 "
 "   keymap_fim_trigger:     keymap to trigger the completion, default: <C-F>
@@ -93,6 +95,7 @@ let s:default_config = {
     \ 'keymap_inst_cancel':     "<Esc>",
     \ 'keymap_debug_toggle':    "<leader>lld",
     \ 'enable_at_startup':      v:true,
+    \ 'disable_filetypes':      [],
     \ }
 
 let llama_config = get(g:, 'llama_config', s:default_config)
@@ -182,6 +185,28 @@ endfunction
 
 function! s:rand(i0, i1) abort
     return a:i0 + rand() % (a:i1 - a:i0 + 1)
+endfunction
+
+" check if current filetype is in disable_filetypes list and enable/disable accordingly
+function! s:check_filetype()
+    let l:current_ft = &filetype
+
+    " skip if not in a real buffer
+    if !buflisted(bufnr('%')) || !filereadable(expand('%'))
+        return
+    endif
+
+    if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
+        " filetype is disabled, ensure plugin is disabled
+        if s:llama_enabled
+            call llama#disable()
+        endif
+    else
+        " filetype is not disabled, ensure plugin is enabled (if not already)
+        if !s:llama_enabled
+            call llama#enable()
+        endif
+    endif
 endfunction
 
 function! llama#disable()
@@ -346,11 +371,21 @@ function! llama#setup_autocmds()
 
         " gather chunk upon saving the file
         autocmd BufWritePost    * call s:pick_chunk(getline(max([1, line('.') - g:llama_config.ring_chunk_size/2]), min([line('.') + g:llama_config.ring_chunk_size/2, line('$')])), v:true, v:true)
+
+        " check filetype on buffer enter and enable/disable accordingly
+        autocmd BufEnter        * call s:check_filetype()
     augroup END
 endfunction
 
 function! llama#enable()
     if s:llama_enabled
+        return
+    endif
+
+    " check if current filetype is in disable_filetypes list
+    let l:current_ft = &filetype
+    if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
+        call llama#debug_log('plugin not enabled for filetype: ' . l:current_ft)
         return
     endif
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -97,7 +97,7 @@ let s:default_config = {
     \ 'keymap_inst_cancel':     "<Esc>",
     \ 'keymap_debug_toggle':    "<leader>lld",
     \ 'enable_at_startup':      v:true,
-    \ 'disabled_filetypes':      [],
+    \ 'disabled_filetypes':     [],
     \ 'enabled_filetypes':      [],
     \ }
 
@@ -198,6 +198,9 @@ function! s:check_filetype()
     if !buflisted(bufnr('%')) || !filereadable(expand('%'))
         return
     endif
+
+    call llama#debug_log('check_filetype for filetype: ' . l:current_ft)
+
 
     if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
         " filetype is disabled, disabled plugin

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -201,8 +201,10 @@ function! s:check_filetype()
 
     call llama#debug_log('check_filetype for filetype: ' . l:current_ft)
 
+    let l:is_disabled = index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 || index(g:llama_config.disabled_filetypes, '*') >= 0
+    let l:is_enabled = index(g:llama_config.enabled_filetypes, l:current_ft) >= 0 || index(g:llama_config.enabled_filetypes, '*') >= 0
 
-    if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
+    if l:is_disabled && !l:is_enabled
         " filetype is disabled, disabled plugin
             call llama#debug_log('1')
         if s:llama_enabled

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -204,7 +204,9 @@ function! s:check_filetype()
 
     if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
         " filetype is disabled, disabled plugin
+            call llama#debug_log('1')
         if s:llama_enabled
+            call llama#debug_log('about to disable')
             call llama#disable()
 
             " now that llama is disabled the autocmd group will not be called
@@ -219,6 +221,7 @@ function! s:check_filetype()
         endif
     else
         if !s:llama_enabled
+            call llama#debug_log('about to enable')
             call llama#enable()
         endif
     endif

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -213,7 +213,9 @@ function! s:check_filetype()
             " NOTE because of this, if the user disables the plugin manually, 
             " This filetype check will not be performed until the user
             " manually re-enables the plugin. 
-            autocmd BufEnter        * call s:check_filetype()
+            augroup llama_filetype_check
+                autocmd BufEnter * call s:check_filetype()
+            augroup END
         endif
     else
         if !s:llama_enabled
@@ -226,6 +228,7 @@ function! llama#disable()
     call llama#fim_hide()
 
     autocmd! llama
+    autocmd! llama_filetype_check
 
     " TODO: these unmaps don't seem to work properly
     if g:llama_config.keymap_fim_trigger != ''
@@ -395,6 +398,9 @@ function! llama#enable()
     let l:current_ft = &filetype
     if index(g:llama_config.disabled_filetypes, l:current_ft) >= 0 && index(g:llama_config.enabled_filetypes, l:current_ft) == -1
         call llama#debug_log('plugin not enabled for filetype: ' . l:current_ft)
+        augroup llama_filetype_check
+            autocmd BufEnter * call s:check_filetype()
+        augroup END
         return
     endif
 

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -192,9 +192,9 @@ function! s:check_filetype()
     let l:current_ft = &filetype
 
     " skip if not in a listed buffer
-    if !buflisted(bufnr('%'))
-        return
-    endif
+    "if !buflisted(bufnr('%'))
+    "    return
+    "endif
 
     if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
         " filetype is disabled, ensure plugin is disabled

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -214,6 +214,10 @@ function! llama#disable()
 
     autocmd! llama
 
+    " only remove autocmds that are active when plugin is enabled
+    " keep BufEnter for filetype checking so plugin can re-enable
+    autocmd BufEnter        * call s:check_filetype()
+
     " TODO: these unmaps don't seem to work properly
     if g:llama_config.keymap_fim_trigger != ''
         exe "silent! iunmap <buffer> " .. g:llama_config.keymap_fim_trigger

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -191,10 +191,15 @@ endfunction
 function! s:check_filetype()
     let l:current_ft = &filetype
 
-    " skip if not in a listed buffer
+    "" skip if not in a listed buffer
     "if !buflisted(bufnr('%'))
     "    return
     "endif
+    
+    " skip if not in a real buffer
+    if !buflisted(bufnr('%')) || !filereadable(expand('%'))
+        return
+    endif
 
     if index(g:llama_config.disable_filetypes, l:current_ft) >= 0
         " filetype is disabled, ensure plugin is disabled

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -183,7 +183,7 @@ Currently the default config is:
 - {disabled_filetypes}	list of filetypes to disable code completion for
                         (default: []). When the current filetype is in this
                         list, code completion will not be triggered.
-                        NOTE if set to [""] all files will be blanket
+                        NOTE if set to ['*'] all files will be blanket
                         disabled, this is useful for using with
                         enabled_filetypes.
 

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -180,6 +180,10 @@ Currently the default config is:
 - {enable_at_startup}	whether to enable llama.vim functionality at startup
 						(v:true to enable, v:false to disable; default: v:true)
 
+- {disable_filetypes}	list of filetypes to disable code completion for
+                        (default: []). When the current filetype is in this
+                        list, code completion will not be triggered.
+
 parameters for the ring-buffer with extra context:
 
 - {ring_n_chunks}		max number of chunks to pass as extra context to the

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -180,9 +180,17 @@ Currently the default config is:
 - {enable_at_startup}	whether to enable llama.vim functionality at startup
 						(v:true to enable, v:false to disable; default: v:true)
 
-- {disable_filetypes}	list of filetypes to disable code completion for
+- {disabled_filetypes}	list of filetypes to disable code completion for
                         (default: []). When the current filetype is in this
                         list, code completion will not be triggered.
+                        NOTE if set to [""] all files will be blanket
+                        disabled, this is useful for using with
+                        enabled_filetypes.
+
+- {enabled_filetypes}	list of filetypes to enable code completion for
+                        (default: []). When the current filetype is in this
+                        list, code completion will be triggered. Enabled
+                        filetypes override any disabled matches.
 
 parameters for the ring-buffer with extra context:
 


### PR DESCRIPTION
closes #118 

Pretty straight forward functionality. Will gladly make any requested changes if there is a desire to merge this!

I tested it manually, both setups in the readme work

-----------
from the README updates: 

```markdown
6. Disable code completion for certain filetypes (e.g., markdown)

    ```vim
    let g:llama_config = { 'disabled_filetypes': ['markdown', 'text'] }
    ```

    Or with lazy.nvim:

    ```lua
    {
        'ggml-org/llama.vim',
        init = function()
            vim.g.llama_config = {
                disabled_filetypes = { 'markdown', 'text'},
            }
        end,
    }
    ```

    This will prevent the plugin from enabling when the filetype matches any
    of the entries in the `disabled_filetypes` list. 

    Additionally, using `enabled_filetypes` one can disable code completion for
    all filetypes, then further only enabled it for specific filetypes. eg:

    ```vim
    let g:llama_config = { 'disabled_filetypes': ['*'], 'enabled_filetypes': ['rust']  }
    ```

```