### PR TITLE
Add inst_stop_strings configuration

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -23,7 +23,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   n_prefix:         number of lines before the cursor location to include in the local prefix
 "   n_suffix:         number of lines after  the cursor location to include in the local suffix
 "   n_predict:        max number of tokens to predict
-"   stop_strings      return the result immediately as soon as any of these strings are encountered in the generated text
+"   stop_strings_fim  return the result immediately as soon as any of these strings are encountered in the generated text for FIM completions
+"   stop_strings_inst return the result immediately as soon as any of these strings are encountered in the generated text for instruction completions
 "   t_max_prompt_ms:  max alloted time for the prompt processing (TODO: not yet supported)
 "   t_max_predict_ms: max alloted time for the prediction
 "   show_info:        show extra info about the inference (0 - disabled, 1 - statusline, 2 - inline)
@@ -71,7 +72,8 @@ let s:default_config = {
     \ 'n_prefix':               256,
     \ 'n_suffix':               64,
     \ 'n_predict':              128,
-    \ 'stop_strings':           [],
+    \ 'stop_strings_fim':       [],
+    \ 'stop_strings_inst':      [],
     \ 't_max_prompt_ms':        500,
     \ 't_max_predict_ms':       1000,
     \ 'show_info':              2,
@@ -106,6 +108,7 @@ let s:renames = {
       \ 'keymap_accept_line' : 'keymap_fim_accept_line',
       \ 'keymap_accept_word' : 'keymap_fim_accept_word',
       \ 'keymap_debug'       : 'keymap_debug_toggle',
+      \ 'stop_strings'       : 'stop_strings_fim',
       \ }
 
 for [old_key, new_key] in items(s:renames)
@@ -800,7 +803,7 @@ function! llama#fim(pos_x, pos_y, is_auto, prev, use_cache) abort
         \ 'input_extra':      l:extra,
         \ 'prompt':           l:middle,
         \ 'n_predict':        g:llama_config.n_predict,
-        \ 'stop':             g:llama_config.stop_strings,
+        \ 'stop':             g:llama_config.stop_strings_fim,
         \ 'n_indent':         l:indent,
         \ 'top_k':            40,
         \ 'top_p':            0.90,
@@ -1399,6 +1402,7 @@ function! llama#inst(l0, l1)
         \ 'samplers':     [],
         \ 'n_predict':    0,
         \ 'stream':       v:false,
+        \ 'stop':         g:llama_config.stop_strings_inst,
         \ 'cache_prompt': v:true,
         \ 'response_fields':  [""],
         \ }
@@ -1494,6 +1498,7 @@ function! llama#inst_send(req_id, messages)
         \ 'min_p':        0.1,
         \ 'temperature':  0.1,
         \ 'samplers':     ["min_p", "temperature"],
+        \ 'stop':         g:llama_config.stop_strings_inst,
         \ 'stream':       v:true,
         \ 'cache_prompt': v:true,
         \ }


### PR DESCRIPTION
Hi!

I'm experimenting with local llms and this plugin is a hidden gem! I'm surprised that I can have a usable completion experience running locally on my laptop. 

I just had a little problem where the stop characters for the instruct LLM could not be configured, and I needed to configure it. I did the changes on my fork and though it could be upstreamed. If you want to rename the new `inst_stop_strings` option, I'm not attached to the name.

If you are open to the change, I can also change the documentation to make sure the option is well documented.