### PR TITLE
fix: inst mode stuck on "⏳Generating..." after response completes

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1920,6 +1920,10 @@ function! s:inst_on_response(id, job_id, data, event = v:null)
         return
     endif
 
+    if has_key(s:inst_reqs, a:id) && get(s:inst_reqs[a:id], 'completed', v:false)
+    	return
+    endif
+
     let l:content = ''
     for l:line in l:lines
         if len(l:line) > 5 && l:line[:5] ==# 'data: '
@@ -1982,10 +1986,11 @@ function! s:inst_on_exit(id, job_id, exit_code, event = v:null)
         return
     endif
 
+    let l:req = s:inst_reqs[a:id]
+    let l:req.completed = v:true
     call s:inst_update(a:id, 'ready')
 
     " add assistant response to messages for continuation
-    let l:req = s:inst_reqs[a:id]
     call add(l:req.inst_prev, {'role': 'assistant', 'content': l:req.result})
 endfunction
 


### PR DESCRIPTION
***this is all for classic vim***
# The Issue:

Any time I would do `<leader>lli` for instruct, it would often (not all the time) get stuck on ⏳Generating..." after response completes.

I believe this is because there's an assumption that once `inst_on_exit` fires when `curl` process exits, it's in the final state. 
# What was actually happening

```
s:inst_on_response fires      (status → 'gen')
s:inst_on_response fires      (status → 'gen')
... repeats until...
s:inst_on_exit fires.               (status → 'ready')   ← screen should show "✅ Ready! Press <Tab> to accept. " 
s:inst_on_response fires.    (status → 'gen')     ← but this overwrites it back
```

I wouldn't see the `✅ Ready! Press <Tab> to accept. ` because Vim doesn't repaint until there are no more events in the queue. So it never repainted because there was another event (the straggler `out_cb` so it sticks on  `⏳Generating...`

I believe this is because Vim doesn't guarantee that `exit_cb` will be called after `out_cb` every time. Sometimes the buffered `stdout`checks get sent after the exit event. So `curl` might have exited, but Vim still had buffered output sitting in the queue. 

# How this PR resolves the issue

Race condition fix: `s:inst_on_exit` now sets `l:req.completed = v:true` before calling `s:inst_update`. A guard at the top of `s:inst_on_response` returns early if `completed` is true, so late-arriving buffered chunks can no longer overwrite the `'ready'` state.


# How I found it

Printf-debugging with `echom` in the callbacks:

```vim
function! s:inst_on_response(id, job_id, data, event = v:null)
    echom "inst_on_response status=" . get(get(s:inst_reqs, a:id, {}), 'status', 'GONE')
    ...
```
and
```vim
function! s:inst_on_exit(id, job_id, exit_code, event = v:null)
    echom "inst_on_exit called, exit_code=" . a:exit_code
    ...
```

Then checking `:messages` after triggering the bug, which showed `s:inst_on_response` firing with `status=gen` after `s:inst_on_exit` had already fired.