### PR TITLE
Updating default port to 8080 (llama-server default) & harmonising shortcuts in default config & comments

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -59,16 +59,16 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   keymap_fim_accept_word: keymap to accept word suggestion, default: <C-B>
 "   keymap_fim_next:        keymap to cycle to next completion,  default: <C-J>
 "   keymap_fim_prev:        keymap to cycle to prev completion,  default: <C-K>
-"   keymap_debug_toggle:    keymap to toggle the debug pane,  default: null
 "   keymap_inst_trigger:    keymap to trigger the instruction command, default: <leader>lli
 "   keymap_inst_rerun:      keymap to rerun the instruction, default: <leader>llr
 "   keymap_inst_continue:   keymap to continue the instruction, default: <leader>llc
 "   keymap_inst_accept:     keymap to accept the instruction, default: <Tab>
 "   keymap_inst_cancel:     keymap to cancel the instruction, default: <Esc>
+"   keymap_debug_toggle:    keymap to toggle the debug pane,  default: null
 "
 let s:default_config = {
-    \ 'endpoint_fim':           'http://127.0.0.1:8012/infill',
-    \ 'endpoint_inst':          'http://127.0.0.1:8012/v1/chat/completions',
+    \ 'endpoint_fim':           'http://127.0.0.1:8080/infill',
+    \ 'endpoint_inst':          'http://127.0.0.1:8080/v1/chat/completions',
     \ 'model_fim':              '',
     \ 'model_inst':             '',
     \ 'api_key':                '',
@@ -88,10 +88,10 @@ let s:default_config = {
     \ 'ring_chunk_size':        64,
     \ 'ring_scope':             1024,
     \ 'ring_update_ms':         1000,
-    \ 'keymap_fim_trigger':     "<leader>llf",
+    \ 'keymap_fim_trigger':     "<C-F>",
     \ 'keymap_fim_accept_full': "<Tab>",
     \ 'keymap_fim_accept_line': "<S-Tab>",
-    \ 'keymap_fim_accept_word': "<leader>ll]",
+    \ 'keymap_fim_accept_word': "<C-B>",
     \ 'keymap_fim_next':        "<C-J>",
     \ 'keymap_fim_prev':        "<C-K>",
     \ 'keymap_inst_trigger':    "<leader>lli",

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -16,17 +16,18 @@ Requires:
 ================================================================================
 Default Shortcut
 
-- Tab         - accept the current suggestion
-- Shift+Tab   - accept just the first line of the suggestion
-- <leader>ll] - accept just the first word of the suggestion
+- <C-F>       - trigger FIM completion manually
+- <Tab>       - accept the current suggestion
+- <Shift+Tab> - accept just the first line of the suggestion
+- <C-B>       - accept just the first word of the suggestion
 - <C-J>       - cycle to next completion (when multiple are available)
 - <C-K>       - cycle to previous completion (when multiple are available)
-- <leader>llf - trigger FIM completion manually
-- <leader>lli - trigger instruction-based editing (instruct mode)
+- <leader>lli - trigger instruction-based editing (instruct mode, called from
+                visual mode)
 - <leader>llr - rerun the instruction
 - <leader>llc - continue the instruction
-- <leader>llr - accept the instruction (accept the instruction)
-- <leader>llq - cancel the instruction (cancel the instruction)
+- <Tab>       - accept the instruction (accept the instruction)
+- <Esc>       - cancel the instruction (cancel the instruction)
 - <leader>lld - toggle the debug pane
 
 ================================================================================
@@ -107,8 +108,8 @@ variable.
 Currently the default config is:
 >vim
 		let s:default_config = {
-		    \ 'endpoint_fim':           'http://127.0.0.1:8012/infill',
-		    \ 'endpoint_inst':          'http://127.0.0.1:8012/v1/chat/completions',
+		    \ 'endpoint_fim':           'http://127.0.0.1:8080/infill',
+		    \ 'endpoint_inst':          'http://127.0.0.1:8080/v1/chat/completions',
 		    \ 'model_fim':              '',
 		    \ 'model_inst':             '',
 		    \ 'api_key':                '',
@@ -127,10 +128,10 @@ Currently the default config is:
 		    \ 'ring_chunk_size':        64,
 		    \ 'ring_scope':             1024,
 		    \ 'ring_update_ms':         1000,
-		    \ 'keymap_fim_trigger':     "<leader>llf",
+		    \ 'keymap_fim_trigger':     "<C-F>",
 		    \ 'keymap_fim_accept_full': "<Tab>",
 		    \ 'keymap_fim_accept_line': "<S-Tab>",
-		    \ 'keymap_fim_accept_word': "<leader>ll]",
+		    \ 'keymap_fim_accept_word': "<C-B>",
 		    \ 'keymap_fim_next':        "<C-J>",
 		    \ 'keymap_fim_prev':        "<C-K>",
 		    \ 'keymap_inst_trigger':    "<leader>lli",


### PR DESCRIPTION
I noticed that the default config was 8012, which doesn't work out of the box with the current `llama-server`.

Also, the documentation/help and the comments in `autoload/llama.vim` did not reflect default config -> fim trigger set to `<C-F>`, etc.

- **core : updating default port, harmonize default shortcuts with comment strings**
- **readme : harmonize default shortcuts with core**
