### PR TITLE
fim : fix empty text prop rendering in classic vim

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1406,21 +1406,24 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
             \ 'virt_lines': map(l:content[1:], {idx, val -> [[val, 'llama_hl_fim_hint']]})
             \ })
     elseif s:ghost_text_vim
-        let l:full_suffix = l:content[0]
-        if !empty(l:full_suffix)
-            let l:new_suffix = l:full_suffix[0:-len(l:line_cur[l:pos_x:])-1]
+        " NOTE: avoid adding text props with empty text - in Vim these render as
+        " garbage bytes at the anchor position
+        let l:new_suffix = l:content[0][0:-len(l:line_cur[l:pos_x:])-1]
+        if !empty(l:new_suffix)
             call prop_add(l:pos_y, l:pos_x + 1, {
                 \ 'type': s:hlgroup_hint,
                 \ 'text': l:new_suffix
                 \ })
         endif
         for line in l:content[1:]
-            call prop_add(l:pos_y, 0, {
-                \ 'type': s:hlgroup_hint,
-                \ 'text': line,
-                \ 'text_padding_left': s:get_indent(line),
-                \ 'text_align': 'below'
-                \ })
+            if !empty(line)
+                call prop_add(l:pos_y, 0, {
+                    \ 'type': s:hlgroup_hint,
+                    \ 'text': line,
+                    \ 'text_padding_left': s:get_indent(line),
+                    \ 'text_align': 'below'
+                    \ })
+            endif
         endfor
         if !empty(l:info)
             call prop_add(l:pos_y, 0, {

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1406,8 +1406,8 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
             \ 'virt_lines': map(l:content[1:], {idx, val -> [[val, 'llama_hl_fim_hint']]})
             \ })
     elseif s:ghost_text_vim
-        " NOTE: avoid adding text props with empty text - in Vim these render as
-        " garbage bytes at the anchor position
+        " note: avoid adding text props with empty text - vim produces garbage
+        " ref: https://github.com/ggml-org/llama.vim/pull/134/
         let l:new_suffix = l:content[0][0:-len(l:line_cur[l:pos_x:])-1]
         if !empty(l:new_suffix)
             call prop_add(l:pos_y, l:pos_x + 1, {


### PR DESCRIPTION
### Problem

In classic Vim, an empty FIM completion is rendered as garbage bytes
(e.g. `test` → `tes���ht`) at the cursor position. This only happens when
`show_info == 2`. In Neovim the same case correctly shows an empty
completion.

### Root cause

When the completion is empty, `content` becomes `['t']` (the empty
suggestion with the existing line suffix appended), and `new_suffix`
computes to `''`. The Vim render path guarded on `!empty(l:full_suffix)`
(which is non-empty), so it still added a text prop with an empty `text`
string. Vim renders empty-text props as garbage bytes at the anchor
position; the artifact is only visible when the inline info text prop is
also present (i.e. `show_info == 2`).

### Fix

In the `s:ghost_text_vim` render path:
- guard the hint text prop on `!empty(l:new_suffix)`, so no empty-text
  prop is created;
- skip empty lines in the below-line loop (same artifact would apply to
  a multi-line suggestion containing a blank line).

Neovim's render path is unchanged.

### Verification

- Reproduced the garbage in Vim in isolation and confirmed the fix
  removes it (`test` + info, no garbage).
- Plugin loads cleanly in both Vim 9.2 and Nvim 0.11.

---

**AI usage disclosure:** YES. llama.cpp:DeepSeek-4-Flash-0731
