### PR TITLE
Add configuration to make info message more compact

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -29,7 +29,7 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   t_max_prompt_ms:  max alloted time for the prompt processing (TODO: not yet supported)
 "   t_max_predict_ms: max alloted time for the prediction
 "   show_info:        show extra info about the inference (0 - disabled, 1 - statusline, 2 - inline)
-"   compact_info:     info message length (0 - full, 1 - short ms and t/s, 2 - remove t/s, 3 - also remove e:, q:, C:, 4 - only c: and r:)
+"   info_compact:     info message length (0 - full, 1 - short ms and t/s, 2 - remove t/s, 3 - also remove e:, q:, C:, 4 - only c: and r:)
 "   auto_fim:         trigger FIM completion automatically on cursor movement
 "   max_line_suffix:  do not auto-trigger FIM completion if there are more than this number of characters to the right of the cursor
 "   max_cache_keys:   max number of cached completions to keep in result_cache
@@ -82,7 +82,7 @@ let s:default_config = {
     \ 't_max_prompt_ms':        500,
     \ 't_max_predict_ms':       1000,
     \ 'show_info':              2,
-    \ 'compact_info':           0,
+    \ 'info_compact':           0,
     \ 'auto_fim':               v:true,
     \ 'max_line_suffix':        8,
     \ 'max_cache_keys':         250,
@@ -1380,12 +1380,12 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
                 \ l:cmpl_idx
                 \ )
         else
-            " make sure compact_info is in a valid range
-            if g:llama_config.compact_info < 0
-                let g:llama_config.compact_info = 0
+            " make sure info_compact is in a valid range
+            if g:llama_config.info_compact < 0
+                let g:llama_config.info_compact = 0
             endif
-            if g:llama_config.compact_info > 4
-                let g:llama_config.compact_info = 4
+            if g:llama_config.info_compact > 4
+                let g:llama_config.info_compact = 4
             endif
 
             " always print c: and r:
@@ -1395,17 +1395,17 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
                 \ )
 
             " add e:, q:, C: in compact levels 0 to 2
-            if g:llama_config.compact_info < 3
+            if g:llama_config.info_compact < 3
                 let l:info = l:info . printf(", e: %d, q: %d/16, C: %d",
                     \ s:ring_n_evict, len(s:ring_queued), s:cache_count()
                     \ )
             endif
 
             " add p: and g: (in varying precision and detail) in compact levels 0 to 3
-            if g:llama_config.compact_info == 0 || g:llama_config.compact_info == 1
-                if g:llama_config.compact_info == 0
+            if g:llama_config.info_compact == 0 || g:llama_config.info_compact == 1
+                if g:llama_config.info_compact == 0
                     let l:template = " | p: %d (%.2f ms, %.2f t/s) | g: %d (%.2f ms, %.2f t/s)%s"
-                elseif g:llama_config.compact_info == 1
+                elseif g:llama_config.info_compact == 1
                     let l:template = " | p: %d (%.0f ms, %.0f t/s) | g: %d (%.0f ms, %.0f t/s)%s"
                 endif
                 let l:info = l:info . printf(l:template,
@@ -1413,7 +1413,7 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
                     \ l:n_predict, l:t_predict_ms, l:s_predict,
                     \ l:cmpl_idx
                     \ )
-            elseif g:llama_config.compact_info < 4
+            elseif g:llama_config.info_compact < 4
                 let l:info = l:info . printf(" | p: %d (%.0f ms) | g: %d (%.0f ms)%s",
                     \ l:n_prompt, l:t_prompt_ms, l:n_predict, l:t_predict_ms, l:cmpl_idx
                     \ )

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -29,6 +29,7 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   t_max_prompt_ms:  max alloted time for the prompt processing (TODO: not yet supported)
 "   t_max_predict_ms: max alloted time for the prediction
 "   show_info:        show extra info about the inference (0 - disabled, 1 - statusline, 2 - inline)
+"   compact_info:     info message length (0 - full, 1 - short ms and t/s, 2 - remove t/s, 3 - also remove e:, q:, C:, 4 - only c: and r:)
 "   auto_fim:         trigger FIM completion automatically on cursor movement
 "   max_line_suffix:  do not auto-trigger FIM completion if there are more than this number of characters to the right of the cursor
 "   max_cache_keys:   max number of cached completions to keep in result_cache
@@ -81,6 +82,7 @@ let s:default_config = {
     \ 't_max_prompt_ms':        500,
     \ 't_max_predict_ms':       1000,
     \ 'show_info':              2,
+    \ 'compact_info':           0,
     \ 'auto_fim':               v:true,
     \ 'max_line_suffix':        8,
     \ 'max_cache_keys':         250,
@@ -1378,14 +1380,44 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
                 \ l:cmpl_idx
                 \ )
         else
-            let l:info = printf("%s | c: %d, r: %d/%d, e: %d, q: %d/16, C: %d | p: %d (%.2f ms, %.2f t/s) | g: %d (%.2f ms, %.2f t/s)%s",
+            " make sure compact_info is in a valid range
+            if g:llama_config.compact_info < 0
+                let g:llama_config.compact_info = 0
+            endif
+            if g:llama_config.compact_info > 4
+                let g:llama_config.compact_info = 4
+            endif
+
+            " always print c: and r:
+            let l:info = printf("%s | c: %d, r: %d/%d",
                 \ g:llama_config.show_info == 2 ? l:prefix : 'llama.vim',
-                \ l:n_cached,  len(s:ring_chunks), g:llama_config.ring_n_chunks, s:ring_n_evict, len(s:ring_queued),
-                \ s:cache_count(),
-                \ l:n_prompt,  l:t_prompt_ms,  l:s_prompt,
-                \ l:n_predict, l:t_predict_ms, l:s_predict,
-                \ l:cmpl_idx
+                \ l:n_cached, len(s:ring_chunks), g:llama_config.ring_n_chunks
                 \ )
+
+            " add e:, q:, C: in compact levels 0 to 2
+            if g:llama_config.compact_info < 3
+                let l:info = l:info . printf(", e: %d, q: %d/16, C: %d",
+                    \ s:ring_n_evict, len(s:ring_queued), s:cache_count()
+                    \ )
+            endif
+
+            " add p: and g: (in varying precision and detail) in compact levels 0 to 3
+            if g:llama_config.compact_info == 0 || g:llama_config.compact_info == 1
+                if g:llama_config.compact_info == 0
+                    let l:template = " | p: %d (%.2f ms, %.2f t/s) | g: %d (%.2f ms, %.2f t/s)%s"
+                elseif g:llama_config.compact_info == 1
+                    let l:template = " | p: %d (%.0f ms, %.0f t/s) | g: %d (%.0f ms, %.0f t/s)%s"
+                endif
+                let l:info = l:info . printf(l:template,
+                    \ l:n_prompt,  l:t_prompt_ms,  l:s_prompt,
+                    \ l:n_predict, l:t_predict_ms, l:s_predict,
+                    \ l:cmpl_idx
+                    \ )
+            elseif g:llama_config.compact_info < 4
+                let l:info = l:info . printf(" | p: %d (%.0f ms) | g: %d (%.0f ms)%s",
+                    \ l:n_prompt, l:t_prompt_ms, l:n_predict, l:t_predict_ms, l:cmpl_idx
+                    \ )
+            endif
         endif
 
         if g:llama_config.show_info == 1


### PR DESCRIPTION
Hi,
I made these changes around a year ago, and then, embarrassingly... forgot to actually open the pull request. I rebased the code today and it still seems to be working fine, so here it is in case someone finds it useful.

----
Hi,

I've been using llama.vim occasionally for a while now, and started it use more again with the release of Qwen3 Coder. So I wanted to address one little annoyance I had with the stats printout – namely that it is unnecessarily long and detailed.

When you are editing in a small window (or have multiple splits open), the info message very often does not fit and gets cut off. Moving it to the status line helps a little, but then it replaces useful stuff like file name and current line / column indicators. So I would prefer keeping it inline, but make it shorter and limited only to information I'm interested in.

Most of the time I only care about used context and ring buffer state, sometimes a little bit more if I'm tweaking parameters for a new model. Others may have different preferences, so I introduced a new parameter `compact_info` that lets you choose a "level of compactness" ranging from 0 to 4. (0 is the original format, 1 gets rid of float decimal places, 2 removes t/s stats, 3 removes evictions, queue and cache stats, and 4 keeps only context and ring buffer usage.)

Examples of `compact_info` set to 0, 1, 2, 3 and 4:  // from the 2025 version, before rebase
```
llama.vim | c: 151, r: 0/18, e: 0, q: 1/16, C: 2/250 | p: 133 (204.18 ms, 651.37 t/s) | g: 14 (212.88 ms, 65.77 t/s)
llama.vim | c: 155, r: 0/18, e: 0, q: 1/16, C: 2/250 | p: 133 (205 ms, 650 t/s) | g: 18 (278 ms, 65 t/s)
llama.vim | c: 150, r: 0/18, e: 0, q: 1/16, C: 2/250 | p: 133 (206 ms) | g: 13 (197 ms)
llama.vim | c: 151, r: 0/18 | p: 133 (205 ms) | g: 14 (213 ms)
llama.vim | c: 161, r: 0/18
```

I don't have `nvim` set up, so it's tested only in plain `vim` (9.1.1244), though I would not expect any issues as it basically just changes the contents of one string...