### PR TITLE
config : change default info_compact value to 3

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -82,7 +82,7 @@ let s:default_config = {
     \ 't_max_prompt_ms':        500,
     \ 't_max_predict_ms':       1000,
     \ 'show_info':              2,
-    \ 'info_compact':           0,
+    \ 'info_compact':           3,
     \ 'auto_fim':               v:true,
     \ 'max_line_suffix':        8,
     \ 'max_cache_keys':         250,

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -121,7 +121,7 @@ Currently the default config is:
 		    \ 't_max_prompt_ms':        500,
 		    \ 't_max_predict_ms':       1000,
 		    \ 'show_info':              2,
-		    \ 'info_compact':           0,
+		    \ 'info_compact':           3,
 		    \ 'auto_fim':               v:true,
 		    \ 'max_line_suffix':        8,
 		    \ 'max_cache_keys':         250,

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -121,6 +121,7 @@ Currently the default config is:
 		    \ 't_max_prompt_ms':        500,
 		    \ 't_max_predict_ms':       1000,
 		    \ 'show_info':              2,
+		    \ 'info_compact':           0,
 		    \ 'auto_fim':               v:true,
 		    \ 'max_line_suffix':        8,
 		    \ 'max_cache_keys':         250,
@@ -183,6 +184,10 @@ Currently the default config is:
 
 - {show_info}			show extra info about the inference
 						(0 - disabled, 1 - statusline, 2 - inline)
+
+- {info_compact}		info message length
+						(0 - full, 1 - short ms and t/s, 2 - remove t/s,
+						3 - also remove e:, q:, C:, 4 - only c: and r:)
 
 - {auto_fim}			trigger FIM completion automatically on cursor movement
 


### PR DESCRIPTION
## Description

Updates the default value of the `info_compact` config option from `0` (full info message) to `3` (compact, showing only `c:`/`r:` and rounded ms).

Also documents the `info_compact` option in `doc/llama.txt`, which was missed in #135.

## Changes

- `autoload/llama.vim`: default `info_compact` changed 0 → 3
- `doc/llama.txt`: document `info_compact` option (0-4 levels) and update default config block

## Related

- Follow-up to #135

Assisted-by: llama.cpp:DeepSeek-V4-Flash-0731