### PR TITLE
fim : fix accept keys inserting the mapping as text

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -1467,14 +1467,18 @@ function! s:fim_render(pos_x, pos_y, responses, selected)
     endif
 
     " setup accept shortcuts
+    " note: use CTRL-\ CTRL-O - plain CTRL-O is a completion key (i_CTRL-X_CTRL-O), so it is
+    "       swallowed while insert-mode completion is active and the rest of the mapping
+    "       ends up being inserted as text
+    " ref: https://github.com/ggml-org/llama.vim/issues/38
     if g:llama_config.keymap_fim_accept_full != ''
-        exe 'inoremap <buffer> ' . g:llama_config.keymap_fim_accept_full . ' <C-O>:call llama#fim_accept(''full'')<CR>'
+        exe 'inoremap <buffer> ' . g:llama_config.keymap_fim_accept_full . ' <C-\><C-O>:call llama#fim_accept(''full'')<CR>'
     endif
     if g:llama_config.keymap_fim_accept_line != ''
-        exe 'inoremap <buffer> ' . g:llama_config.keymap_fim_accept_line . ' <C-O>:call llama#fim_accept(''line'')<CR>'
+        exe 'inoremap <buffer> ' . g:llama_config.keymap_fim_accept_line . ' <C-\><C-O>:call llama#fim_accept(''line'')<CR>'
     endif
     if g:llama_config.keymap_fim_accept_word != ''
-        exe 'inoremap <buffer> ' . g:llama_config.keymap_fim_accept_word . ' <C-O>:call llama#fim_accept(''word'')<CR>'
+        exe 'inoremap <buffer> ' . g:llama_config.keymap_fim_accept_word . ' <C-\><C-O>:call llama#fim_accept(''word'')<CR>'
     endif
 
     " setup cycle shortcuts (always, to prevent <C-J>/<C-K> from moving the cursor)


### PR DESCRIPTION
Fixes #38.

### Problem

The accept keys sometimes insert `:call llama#fim_accept('full')` into the buffer as literal text instead of accepting the suggestion.

### Cause

`s:fim_render()` maps the accept keys to `<C-O>:call llama#fim_accept(...)<CR>`.

`CTRL-O` is also a completion key: `i_CTRL-X_CTRL-O` is omni completion. While CTRL-X omni completion is active, Vim treats `CTRL-O` as "keep completing" and consumes it, so `i_CTRL-O` never runs and the remaining characters of the mapping are typed into the buffer.

Everyone who reported this uses ALE with `g:ale_completion_enabled`. ALE opens its menu with

```vim
inoremap <silent> <Plug>(ale_show_completion_menu) <C-x><C-o><C-p>
```

(`ale/autoload/ale/completion.vim`), which is omni completion, so an ALE user is in CTRL-X omni mode exactly when pressing `<Tab>`.

The existing `pumvisible()` guard in `s:fim_render()` and the `CompleteChanged` -> `llama#fim_hide()` autocmd only know about the popup menu. CTRL-X mode can be active with no popup drawn at all (a single match, or `completeopt` without `menuone`), so neither guard applies and the mapping stays installed.

### Fix

Use `i_CTRL-\_CTRL-O` instead. It has the same "run one command, stay in insert mode" behaviour, but `CTRL-\` is not a completion key in any CTRL-X mode.

The only difference from `i_CTRL-O` is that it does not re-snap the cursor to end-of-line afterwards. That does not matter here because `llama#fim_accept()` sets the cursor itself with `cursor()`. I checked the post-accept cursor position at end-of-line, end-of-file, mid-line and on empty lines: identical before and after.

### Testing

Headless, against a stub llama-server, on Neovim 0.12.2 (`s:ghost_text_nvim`) and Vim 9.1 (`s:ghost_text_vim`), 20 scenarios each.

Before, both editors:

```
    fmt.Printf(:call llama#fim_accept('full')
```

After, both editors:

```
    fmt.Printf("AAA %d\n", zzz)
SECOND_LINE_AAA
THIRD_LINE_AAA
```

Only the omni-completion scenarios change. Accept full/line/word, `<C-J>`/`<C-K>` cycling, plain `<Tab>` with no hint shown, the popup-menu cases, and all cursor positions are byte-identical before and after.

### Relation to #89

#89 targets the same issue with `<ESC>...a`, which @ggerganov reported breaks accept in classic Vim. `<C-\><C-O>` was suggested by @nolsto in https://github.com/ggml-org/llama.vim/pull/89#issuecomment-3564380064 but never turned into a PR. This implements that suggestion, with the root cause identified and both editors tested, so it should supersede #89.

### AI usage disclosure

YES. Claude Opus 5 was used to investigate the root cause and to build the headless test harness. I reviewed the change and can explain it.
