### PR TITLE
core : add server profiles feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Examples:
 
 Use `:LlamaServer` to show the available profiles and `:LlamaServer spark`
 to switch both FIM and instruction requests to another server. Profile names
-support command-line completion.
+support command-line completion. The selected profile is persisted and
+`:LlamaServerReset` can be used to restore the profile (or custom endpoints)
+configured in `.vimrc`.
 
 This only allows the host servers to be specified, not the models used which are
 configured using `model_fim` and `model_inst`. But using consistent naming

--- a/README.md
+++ b/README.md
@@ -109,17 +109,17 @@ Examples:
 6. Configure named llama.cpp servers:
 
     ```vim
-    let g:llama_config.server_profiles = {
+    let g:llama_config.profiles = {
         \ 'spark':   'http://192.168.0.66:8080',
         \ 'gmktec':  'http://192.168.0.65:8080',
         \ }
-    let g:llama_config.server_profile = 'spark'
+    let g:llama_config.profile = 'spark'
     ```
 
-Use `:LlamaServer` to show the available profiles and `:LlamaServer spark`
+Use `:LlamaProfile` to show the available profiles and `:LlamaProfile spark`
 to switch both FIM and instruction requests to another server. Profile names
 support command-line completion. The selected profile is persisted and
-`:LlamaServerReset` can be used to restore the profile (or custom endpoints)
+`:LlamaProfileReset` can be used to restore the profile (or custom endpoints)
 configured in `.vimrc`.
 
 This only allows the host servers to be specified, not the models used which are

--- a/README.md
+++ b/README.md
@@ -106,6 +106,29 @@ Examples:
     let g:llama_config.keymap_inst_cancel   = "<Esc>"
     ```
 
+6. Configure named llama.cpp servers:
+
+    ```vim
+    let g:llama_config.server_profiles = {
+        \ 'spark':   'http://192.168.0.66:8080',
+        \ 'gmktec':  'http://192.168.0.65:8080',
+        \ }
+    let g:llama_config.server_profile = 'spark'
+    ```
+
+Use `:LlamaServer` to show the available profiles and `:LlamaServer spark`
+to switch both FIM and instruction requests to another server. Profile names
+support command-line completion.
+
+This only allows the host servers to be specified, not the models used which are
+configured using `model_fim` and `model_inst`. But using consistent naming
+accross servers, or using server aliases, one can make this independant of the
+actual selected profile. For example, using something like:
+```console
+    \ 'model_fim':              'fim_model',
+    \ 'model_inst':             'inst_model',
+```
+
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)
 for the full list of options.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ actual selected profile. For example, using something like:
     \ 'model_fim':              'fim_model',
     \ 'model_inst':             'inst_model',
 ```
+And then in the server configuration, something like the following can be used:
+```console
+[qwen3.8-27B]
+alias                = inst_model,pi
+```
+And likewise for the fim_model.
 
 Please refer to `:help llama_config` or the [source](./autoload/llama.vim)
 for the full list of options.

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -139,6 +139,12 @@ endfor
 
 let g:llama_config = extendnew(s:default_config, llama_config, 'force')
 
+" Keep the configured values separate from a profile restored from the previous
+" session.  :LlamaServerReset uses these values to return to the .vimrc setup.
+let s:default_server_profile = g:llama_config.server_profile
+let s:default_endpoint_fim   = g:llama_config.endpoint_fim
+let s:default_endpoint_inst  = g:llama_config.endpoint_inst
+
 let s:llama_enabled = v:false
 
 " containes cached responses from the server
@@ -158,6 +164,81 @@ endfunction
 
 function! llama#server_profile_complete(arglead, cmdline, cursorpos)
     return filter(s:server_profile_names(), 'stridx(v:val, a:arglead) == 0')
+endfunction
+
+function! s:server_profile_state_file()
+    " Allow configuration (.vimrc) of where the state file is stored.
+    let l:file = get(g:, 'llama_server_profile_state_file', '')
+    if type(l:file) == v:t_string && !empty(l:file)
+        return expand(l:file)
+    endif
+
+    " If Vim/Noevim has a stdpath defined the we use the state filesystem
+    " location.
+    if exists('*stdpath')
+        try
+            return stdpath('state') . '/llama/server_profile'
+        catch
+        endtry
+    endif
+
+    " Fallback to the user's home .vim directory.
+    return expand('~/.vim/llama-server-profile')
+endfunction
+
+function! s:save_server_profile(profile)
+    let l:file = s:server_profile_state_file()
+    try
+        call mkdir(fnamemodify(l:file, ':h'), 'p', 0700)
+        call writefile([a:profile], l:file)
+    catch
+        echohl WarningMsg
+        echomsg 'llama.vim: could not save server profile state'
+        echohl None
+    endtry
+endfunction
+
+function! s:restore_server_profile()
+    let l:file = s:server_profile_state_file()
+    if !filereadable(l:file)
+        return
+    endif
+
+    try
+        let l:profile = get(readfile(l:file), 0, '')
+    catch
+        return
+    endtry
+
+    if type(g:llama_config.server_profiles) == v:t_dict && has_key(g:llama_config.server_profiles, l:profile)
+        let g:llama_config.server_profile = l:profile
+    endif
+endfunction
+
+function! llama#server_profile_reset()
+    let g:llama_config.endpoint_fim   = s:default_endpoint_fim
+    let g:llama_config.endpoint_inst  = s:default_endpoint_inst
+    let g:llama_config.server_profile = s:default_server_profile
+
+    if !empty(s:default_server_profile)
+        call llama#server_profile(s:default_server_profile, v:true, v:false)
+    endif
+
+    let l:file = s:server_profile_state_file()
+    if filereadable(l:file)
+        try
+            call delete(l:file)
+        catch
+            echohl WarningMsg
+            echomsg 'llama.vim: could not clear server profile state'
+            echohl None
+            return
+        endtry
+    endif
+
+    echo 'Restored default llama server: ' . (empty(s:default_server_profile)
+        \ ? '(custom endpoints)'
+        \ : s:default_server_profile)
 endfunction
 
 function! llama#server_profile(name, ...)
@@ -220,6 +301,10 @@ function! llama#server_profile(name, ...)
 
     if !get(a:, 1, v:false)
         echo 'Using llama server: ' . a:name . ' (' . l:base . ')'
+    endif
+
+    if get(a:, 2, !get(a:, 1, v:false))
+        call s:save_server_profile(a:name)
     endif
 endfunction
 
@@ -507,6 +592,7 @@ function! llama#setup()
     command! LlamaToggleAutoFim  call llama#toggle_auto_fim()
     command! LlamaStatus         call llama#status()
     command! -nargs=? -complete=customlist,llama#server_profile_complete LlamaServer call llama#server_profile(<q-args>)
+    command! LlamaServerReset call llama#server_profile_reset()
 
     command! -range=% LlamaInstruct call llama#inst(<line1>, <line2>)
 
@@ -574,8 +660,9 @@ function! llama#init()
         endif
     endif
 
+    call s:restore_server_profile()
     if !empty(g:llama_config.server_profile)
-        call llama#server_profile(g:llama_config.server_profile, v:true)
+        call llama#server_profile(g:llama_config.server_profile, v:true, v:false)
     endif
 
     if g:llama_config.enable_at_startup

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -17,8 +17,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "
 "   endpoint_fim:     llama.cpp server endpoint for FIM completion
 "   endpoint_inst:    llama.cpp server endpoint for instruction completion
-"   server_profiles:  named llama.cpp server base URLs
-"   server_profile:   server profile selected at startup (empty to use the endpoints above)
+"   profiles:         named llama.cpp profiles
+"   profile:          profile selected at startup (empty to use the endpoints above)
 "   model_fim:        model name in case when multiple models are loaded (optional, recommended: Qwen3 Coder 30B)
 "   model_inst:       instruction model name (optional, recommended: gpt-oss-120b)
 "   api_key:          llama.cpp server api key (optional)
@@ -72,8 +72,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 let s:default_config = {
     \ 'endpoint_fim':           'http://127.0.0.1:8012/infill',
     \ 'endpoint_inst':          'http://127.0.0.1:8012/v1/chat/completions',
-    \ 'server_profiles':        {},
-    \ 'server_profile':         '',
+    \ 'profiles':               {},
+    \ 'profile':                '',
     \ 'model_fim':              '',
     \ 'model_inst':             '',
     \ 'api_key':                '',
@@ -140,8 +140,8 @@ endfor
 let g:llama_config = extendnew(s:default_config, llama_config, 'force')
 
 " Keep the configured values separate from a profile restored from the previous
-" session.  :LlamaServerReset uses these values to return to the .vimrc setup.
-let s:default_server_profile = g:llama_config.server_profile
+" session.  :LlamaProfileReset uses these values to return to the .vimrc setup.
+let s:default_profile = g:llama_config.profile
 let s:default_endpoint_fim   = g:llama_config.endpoint_fim
 let s:default_endpoint_inst  = g:llama_config.endpoint_inst
 
@@ -154,52 +154,53 @@ let s:llama_enabled = v:false
 let g:cache_data = {}
 let g:cache_lru_order = []
 
-function! s:server_profile_names()
-    if type(g:llama_config.server_profiles) != v:t_dict
+function! s:profile_names()
+    if type(g:llama_config.profiles) != v:t_dict
         return []
     endif
 
-    return sort(keys(g:llama_config.server_profiles))
+    return sort(keys(g:llama_config.profiles))
 endfunction
 
-function! llama#server_profile_complete(arglead, cmdline, cursorpos)
-    return filter(s:server_profile_names(), 'stridx(v:val, a:arglead) == 0')
+function! llama#profile_complete(arglead, cmdline, cursorpos)
+    return filter(s:profile_names(), 'stridx(v:val, a:arglead) == 0')
 endfunction
 
-function! s:server_profile_state_file()
+function! s:profile_state_file()
     " Allow configuration (.vimrc) of where the state file is stored.
-    let l:file = get(g:, 'llama_server_profile_state_file', '')
+    let l:file = get(g:, 'llama_profile_state_file', '')
     if type(l:file) == v:t_string && !empty(l:file)
         return expand(l:file)
     endif
 
-    " If Vim/Noevim has a stdpath defined the we use the state filesystem
+    " If Vim/Neovim provides stdpath(), use its state filesystem
     " location.
     if exists('*stdpath')
         try
-            return stdpath('state') . '/llama/server_profile'
+            return stdpath('state') . '/llama/profile'
         catch
         endtry
     endif
 
     " Fallback to the user's home .vim directory.
-    return expand('~/.vim/llama-server-profile')
+    return expand('~/.vim/llama-profile')
 endfunction
 
-function! s:save_server_profile(profile)
-    let l:file = s:server_profile_state_file()
+
+function! s:save_profile(profile)
+    let l:file = s:profile_state_file()
     try
         call mkdir(fnamemodify(l:file, ':h'), 'p', 0700)
         call writefile([a:profile], l:file)
     catch
         echohl WarningMsg
-        echomsg 'llama.vim: could not save server profile state'
+        echomsg 'llama.vim: could not save profile state'
         echohl None
     endtry
 endfunction
 
-function! s:restore_server_profile()
-    let l:file = s:server_profile_state_file()
+function! s:restore_profile()
+    let l:file = s:profile_state_file()
     if !filereadable(l:file)
         return
     endif
@@ -210,66 +211,66 @@ function! s:restore_server_profile()
         return
     endtry
 
-    if type(g:llama_config.server_profiles) == v:t_dict && has_key(g:llama_config.server_profiles, l:profile)
-        let g:llama_config.server_profile = l:profile
+    if type(g:llama_config.profiles) == v:t_dict && has_key(g:llama_config.profiles, l:profile)
+        let g:llama_config.profile = l:profile
     endif
 endfunction
 
-function! llama#server_profile_reset()
+function! llama#profile_reset()
     let g:llama_config.endpoint_fim   = s:default_endpoint_fim
     let g:llama_config.endpoint_inst  = s:default_endpoint_inst
-    let g:llama_config.server_profile = s:default_server_profile
+    let g:llama_config.profile = s:default_profile
 
-    if !empty(s:default_server_profile)
-        call llama#server_profile(s:default_server_profile, v:true, v:false)
+    if !empty(s:default_profile)
+        call llama#profile(s:default_profile, v:true, v:false)
     endif
 
-    let l:file = s:server_profile_state_file()
+    let l:file = s:profile_state_file()
     if filereadable(l:file)
         try
             call delete(l:file)
         catch
             echohl WarningMsg
-            echomsg 'llama.vim: could not clear server profile state'
+            echomsg 'llama.vim: could not clear profile state'
             echohl None
             return
         endtry
     endif
 
-    echo 'Restored default llama server: ' . (empty(s:default_server_profile)
+    echo 'Restored default llama profile: ' . (empty(s:default_profile)
         \ ? '(custom endpoints)'
-        \ : s:default_server_profile)
+        \ : s:default_profile)
 endfunction
 
-function! llama#server_profile(name, ...)
+function! llama#profile(name, ...)
     if empty(a:name)
-        let l:names = s:server_profile_names()
-        let l:active = empty(g:llama_config.server_profile)
+        let l:names = s:profile_names()
+        let l:active = empty(g:llama_config.profile)
             \ ? '(custom endpoints)'
-            \ : g:llama_config.server_profile
-        echo 'Active llama server: ' . l:active
-        echo 'Available llama servers: ' . (empty(l:names) ? '(none)' : join(l:names, ', '))
+            \ : g:llama_config.profile
+        echo 'Active llama profile: ' . l:active
+        echo 'Available llama profiles: ' . (empty(l:names) ? '(none)' : join(l:names, ', '))
         return
     endif
 
-    if type(g:llama_config.server_profiles) != v:t_dict
+    if type(g:llama_config.profiles) != v:t_dict
         echohl ErrorMsg
-        echo 'llama.vim: server_profiles must be a dictionary'
+        echo 'llama.vim: profiles must be a dictionary'
         echohl None
         return
     endif
 
-    if !has_key(g:llama_config.server_profiles, a:name)
+    if !has_key(g:llama_config.profiles, a:name)
         echohl ErrorMsg
-        echo 'llama.vim: unknown server profile: ' . a:name
+        echo 'llama.vim: unknown profile: ' . a:name
         echohl None
         return
     endif
 
-    let l:base = g:llama_config.server_profiles[a:name]
+    let l:base = g:llama_config.profiles[a:name]
     if type(l:base) != v:t_string || empty(l:base)
         echohl ErrorMsg
-        echo 'llama.vim: server profile must contain a non-empty base URL: ' . a:name
+        echo 'llama.vim: profile must contain a non-empty base URL: ' . a:name
         echohl None
         return
     endif
@@ -277,7 +278,7 @@ function! llama#server_profile(name, ...)
     let l:base = substitute(l:base, '/\+$', '', '')
     let g:llama_config.endpoint_fim = l:base . '/infill'
     let g:llama_config.endpoint_inst = l:base . '/v1/chat/completions'
-    let g:llama_config.server_profile = a:name
+    let g:llama_config.profile = a:name
 
     " Cached and in-flight results belong to the previous endpoint.
     let g:cache_data = {}
@@ -300,11 +301,11 @@ function! llama#server_profile(name, ...)
     endif
 
     if !get(a:, 1, v:false)
-        echo 'Using llama server: ' . a:name . ' (' . l:base . ')'
+        echo 'Using llama profile: ' . a:name . ' (' . l:base . ')'
     endif
 
     if get(a:, 2, !get(a:, 1, v:false))
-        call s:save_server_profile(a:name)
+        call s:save_profile(a:name)
     endif
 endfunction
 
@@ -591,8 +592,8 @@ function! llama#setup()
     command! LlamaToggle         call llama#toggle()
     command! LlamaToggleAutoFim  call llama#toggle_auto_fim()
     command! LlamaStatus         call llama#status()
-    command! -nargs=? -complete=customlist,llama#server_profile_complete LlamaServer call llama#server_profile(<q-args>)
-    command! LlamaServerReset call llama#server_profile_reset()
+    command! -nargs=? -complete=customlist,llama#profile_complete LlamaProfile call llama#profile(<q-args>)
+    command! LlamaProfileReset call llama#profile_reset()
 
     command! -range=% LlamaInstruct call llama#inst(<line1>, <line2>)
 
@@ -660,9 +661,9 @@ function! llama#init()
         endif
     endif
 
-    call s:restore_server_profile()
-    if !empty(g:llama_config.server_profile)
-        call llama#server_profile(g:llama_config.server_profile, v:true, v:false)
+    call s:restore_profile()
+    if !empty(g:llama_config.profile)
+        call llama#profile(g:llama_config.profile, v:true, v:false)
     endif
 
     if g:llama_config.enable_at_startup

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -17,6 +17,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "
 "   endpoint_fim:     llama.cpp server endpoint for FIM completion
 "   endpoint_inst:    llama.cpp server endpoint for instruction completion
+"   server_profiles:  named llama.cpp server base URLs
+"   server_profile:   server profile selected at startup (empty to use the endpoints above)
 "   model_fim:        model name in case when multiple models are loaded (optional, recommended: Qwen3 Coder 30B)
 "   model_inst:       instruction model name (optional, recommended: gpt-oss-120b)
 "   api_key:          llama.cpp server api key (optional)
@@ -70,6 +72,8 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 let s:default_config = {
     \ 'endpoint_fim':           'http://127.0.0.1:8012/infill',
     \ 'endpoint_inst':          'http://127.0.0.1:8012/v1/chat/completions',
+    \ 'server_profiles':        {},
+    \ 'server_profile':         '',
     \ 'model_fim':              '',
     \ 'model_inst':             '',
     \ 'api_key':                '',
@@ -143,6 +147,81 @@ let s:llama_enabled = v:false
 " ref: https://github.com/ggml-org/llama.vim/pull/18
 let g:cache_data = {}
 let g:cache_lru_order = []
+
+function! s:server_profile_names()
+    if type(g:llama_config.server_profiles) != v:t_dict
+        return []
+    endif
+
+    return sort(keys(g:llama_config.server_profiles))
+endfunction
+
+function! llama#server_profile_complete(arglead, cmdline, cursorpos)
+    return filter(s:server_profile_names(), 'stridx(v:val, a:arglead) == 0')
+endfunction
+
+function! llama#server_profile(name, ...)
+    if empty(a:name)
+        let l:names = s:server_profile_names()
+        let l:active = empty(g:llama_config.server_profile)
+            \ ? '(custom endpoints)'
+            \ : g:llama_config.server_profile
+        echo 'Active llama server: ' . l:active
+        echo 'Available llama servers: ' . (empty(l:names) ? '(none)' : join(l:names, ', '))
+        return
+    endif
+
+    if type(g:llama_config.server_profiles) != v:t_dict
+        echohl ErrorMsg
+        echo 'llama.vim: server_profiles must be a dictionary'
+        echohl None
+        return
+    endif
+
+    if !has_key(g:llama_config.server_profiles, a:name)
+        echohl ErrorMsg
+        echo 'llama.vim: unknown server profile: ' . a:name
+        echohl None
+        return
+    endif
+
+    let l:base = g:llama_config.server_profiles[a:name]
+    if type(l:base) != v:t_string || empty(l:base)
+        echohl ErrorMsg
+        echo 'llama.vim: server profile must contain a non-empty base URL: ' . a:name
+        echohl None
+        return
+    endif
+
+    let l:base = substitute(l:base, '/\+$', '', '')
+    let g:llama_config.endpoint_fim = l:base . '/infill'
+    let g:llama_config.endpoint_inst = l:base . '/v1/chat/completions'
+    let g:llama_config.server_profile = a:name
+
+    " Cached and in-flight results belong to the previous endpoint.
+    let g:cache_data = {}
+    let g:cache_lru_order = []
+    if exists('s:current_job_fim') && s:current_job_fim != v:null
+        if s:ghost_text_nvim
+            call jobstop(s:current_job_fim)
+        elseif s:ghost_text_vim
+            call job_stop(s:current_job_fim)
+        endif
+        let s:current_job_fim = v:null
+    endif
+    if exists('s:inst_reqs')
+        for l:id in keys(copy(s:inst_reqs))
+            call s:inst_remove(str2nr(l:id))
+        endfor
+    endif
+    if exists('s:fim_hint_shown')
+        call llama#fim_hide()
+    endif
+
+    if !get(a:, 1, v:false)
+        echo 'Using llama server: ' . a:name . ' (' . l:base . ')'
+    endif
+endfunction
 
 " insert a single completion response into the cache ring buffer for a key
 " the ring buffer holds up to g:llama_config.n_cmpl entries per key
@@ -427,6 +506,7 @@ function! llama#setup()
     command! LlamaToggle         call llama#toggle()
     command! LlamaToggleAutoFim  call llama#toggle_auto_fim()
     command! LlamaStatus         call llama#status()
+    command! -nargs=? -complete=customlist,llama#server_profile_complete LlamaServer call llama#server_profile(<q-args>)
 
     command! -range=% LlamaInstruct call llama#inst(<line1>, <line2>)
 
@@ -492,6 +572,10 @@ function! llama#init()
         if empty(prop_type_get(s:hlgroup_inst_info))
             call prop_type_add(s:hlgroup_inst_info, {'highlight': s:hlgroup_inst_info})
         endif
+    endif
+
+    if !empty(g:llama_config.server_profile)
+        call llama#server_profile(g:llama_config.server_profile, v:true)
     endif
 
     if g:llama_config.enable_at_startup

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -139,12 +139,6 @@ endfor
 
 let g:llama_config = extendnew(s:default_config, llama_config, 'force')
 
-" Keep the configured values separate from a profile restored from the previous
-" session.  :LlamaProfileReset uses these values to return to the .vimrc setup.
-let s:default_profile = g:llama_config.profile
-let s:default_endpoint_fim   = g:llama_config.endpoint_fim
-let s:default_endpoint_inst  = g:llama_config.endpoint_inst
-
 let s:llama_enabled = v:false
 
 " containes cached responses from the server
@@ -153,161 +147,6 @@ let s:llama_enabled = v:false
 " ref: https://github.com/ggml-org/llama.vim/pull/18
 let g:cache_data = {}
 let g:cache_lru_order = []
-
-function! s:profile_names()
-    if type(g:llama_config.profiles) != v:t_dict
-        return []
-    endif
-
-    return sort(keys(g:llama_config.profiles))
-endfunction
-
-function! llama#profile_complete(arglead, cmdline, cursorpos)
-    return filter(s:profile_names(), 'stridx(v:val, a:arglead) == 0')
-endfunction
-
-function! s:profile_state_file()
-    " Allow configuration (.vimrc) of where the state file is stored.
-    let l:file = get(g:, 'llama_profile_state_file', '')
-    if type(l:file) == v:t_string && !empty(l:file)
-        return expand(l:file)
-    endif
-
-    " If Vim/Neovim provides stdpath(), use its state filesystem
-    " location.
-    if exists('*stdpath')
-        try
-            return stdpath('state') . '/llama/profile'
-        catch
-        endtry
-    endif
-
-    " Fallback to the user's home .vim directory.
-    return expand('~/.vim/llama-profile')
-endfunction
-
-
-function! s:save_profile(profile)
-    let l:file = s:profile_state_file()
-    try
-        call mkdir(fnamemodify(l:file, ':h'), 'p', 0700)
-        call writefile([a:profile], l:file)
-    catch
-        echohl WarningMsg
-        echomsg 'llama.vim: could not save profile state'
-        echohl None
-    endtry
-endfunction
-
-function! s:restore_profile()
-    let l:file = s:profile_state_file()
-    if !filereadable(l:file)
-        return
-    endif
-
-    try
-        let l:profile = get(readfile(l:file), 0, '')
-    catch
-        return
-    endtry
-
-    if type(g:llama_config.profiles) == v:t_dict && has_key(g:llama_config.profiles, l:profile)
-        let g:llama_config.profile = l:profile
-    endif
-endfunction
-
-function! llama#profile_reset()
-    let g:llama_config.endpoint_fim   = s:default_endpoint_fim
-    let g:llama_config.endpoint_inst  = s:default_endpoint_inst
-    let g:llama_config.profile = s:default_profile
-
-    if !empty(s:default_profile)
-        call llama#profile(s:default_profile, v:true, v:false)
-    endif
-
-    let l:file = s:profile_state_file()
-    if filereadable(l:file)
-        try
-            call delete(l:file)
-        catch
-            echohl WarningMsg
-            echomsg 'llama.vim: could not clear profile state'
-            echohl None
-            return
-        endtry
-    endif
-
-    echo 'Restored default llama profile: ' . (empty(s:default_profile)
-        \ ? '(custom endpoints)'
-        \ : s:default_profile)
-endfunction
-
-function! llama#profile(name, ...)
-    if empty(a:name)
-        let l:names = s:profile_names()
-        let l:active = empty(g:llama_config.profile)
-            \ ? '(custom endpoints)'
-            \ : g:llama_config.profile
-        echo 'Active llama profile: ' . l:active
-        echo 'Available llama profiles: ' . (empty(l:names) ? '(none)' : join(l:names, ', '))
-        return
-    endif
-
-    if type(g:llama_config.profiles) != v:t_dict
-        echohl ErrorMsg
-        echo 'llama.vim: profiles must be a dictionary'
-        echohl None
-        return
-    endif
-
-    if !has_key(g:llama_config.profiles, a:name)
-        echohl ErrorMsg
-        echo 'llama.vim: unknown profile: ' . a:name
-        echohl None
-        return
-    endif
-
-    let l:base = g:llama_config.profiles[a:name]
-    if type(l:base) != v:t_string || empty(l:base)
-        echohl ErrorMsg
-        echo 'llama.vim: profile must contain a non-empty base URL: ' . a:name
-        echohl None
-        return
-    endif
-
-    let l:base = substitute(l:base, '/\+$', '', '')
-    let g:llama_config.endpoint_fim = l:base . '/infill'
-    let g:llama_config.endpoint_inst = l:base . '/v1/chat/completions'
-    let g:llama_config.profile = a:name
-
-    " Cached and in-flight results belong to the previous endpoint.
-    let g:cache_data = {}
-    let g:cache_lru_order = []
-    if exists('s:current_job_fim') && s:current_job_fim != v:null
-        if s:ghost_text_nvim
-            call jobstop(s:current_job_fim)
-        elseif s:ghost_text_vim
-            call job_stop(s:current_job_fim)
-        endif
-        let s:current_job_fim = v:null
-    endif
-    if exists('s:inst_reqs')
-        for l:id in keys(copy(s:inst_reqs))
-            call s:inst_remove(str2nr(l:id))
-        endfor
-    endif
-    if exists('s:fim_hint_shown')
-        call llama#fim_hide()
-    endif
-
-    if !get(a:, 1, v:false)
-        echo 'Using llama profile: ' . a:name . ' (' . l:base . ')'
-    endif
-
-    if get(a:, 2, !get(a:, 1, v:false))
-        call s:save_profile(a:name)
-    endif
-endfunction
 
 " insert a single completion response into the cache ring buffer for a key
 " the ring buffer holds up to g:llama_config.n_cmpl entries per key
@@ -661,7 +500,7 @@ function! llama#init()
         endif
     endif
 
-    call s:restore_profile()
+    call llama_profile#restore()
     if !empty(g:llama_config.profile)
         call llama#profile(g:llama_config.profile, v:true, v:false)
     endif
@@ -2344,4 +2183,49 @@ endfunction
 
 function! llama#debug_setup() abort
     return llama_debug#setup()
+endfunction
+
+" =====================================
+" Profile helpers
+" =====================================
+function! llama#profile_names() abort
+    return llama_profile#names()
+endfunction
+
+function! llama#profile_complete(arglead, cmdline, cursorpos) abort
+    return llama_profile#complete(a:arglead, a:cmdline, a:cursorpos)
+endfunction
+
+function! llama#profile(name, ...) abort
+    return call('llama_profile#select', [a:name] + a:000)
+endfunction
+
+function! llama#profile_reset() abort
+    return llama_profile#reset()
+endfunction
+
+" Called after a successful profile change. Jobs and cached responses are tied
+" to the old endpoint and must not be reused.
+function! llama#profile_changed() abort
+    let g:cache_data = {}
+    let g:cache_lru_order = []
+
+    if exists('s:current_job_fim') && s:current_job_fim != v:null
+        if s:ghost_text_nvim
+            call jobstop(s:current_job_fim)
+        elseif s:ghost_text_vim
+            call job_stop(s:current_job_fim)
+        endif
+        let s:current_job_fim = v:null
+    endif
+
+    if exists('s:inst_reqs')
+        for l:id in keys(copy(s:inst_reqs))
+            call s:inst_remove(str2nr(l:id))
+        endfor
+    endif
+
+    if exists('s:fim_hint_shown') && s:fim_hint_shown
+        call llama#fim_hide()
+    endif
 endfunction

--- a/autoload/llama_profile.vim
+++ b/autoload/llama_profile.vim
@@ -1,0 +1,146 @@
+" autoload/llama_profile.vim - Profiles for llama.vim
+
+" Keep the configured values separate from a profile restored from the previous
+" session.  :LlamaProfileReset uses these values to return to the .vimrc setup.
+let s:default_profile = g:llama_config.profile
+let s:default_endpoint_fim   = g:llama_config.endpoint_fim
+let s:default_endpoint_inst  = g:llama_config.endpoint_inst
+
+function! llama_profile#names() abort
+    if type(g:llama_config.profiles) != v:t_dict
+        return []
+    endif
+
+    return sort(keys(g:llama_config.profiles))
+endfunction
+
+function! llama_profile#complete(arglead, cmdline, cursorpos) abort
+    return filter(llama_profile#names(), 'stridx(v:val, a:arglead) == 0')
+endfunction
+
+function! s:profile_state_file()
+    " Allow configuration (.vimrc) of where the state file is stored.
+    let l:file = get(g:, 'llama_profile_state_file', '')
+    if type(l:file) == v:t_string && !empty(l:file)
+        return expand(l:file)
+    endif
+
+    " If Vim/Neovim provides stdpath(), use its state filesystem
+    " location.
+    if exists('*stdpath')
+        try
+            return stdpath('state') . '/llama/profile'
+        catch
+        endtry
+    endif
+
+    " Fallback to the user's home .vim directory.
+    return expand('~/.vim/llama-profile')
+endfunction
+
+
+function! s:save_profile(profile)
+    let l:file = s:profile_state_file()
+    try
+        call mkdir(fnamemodify(l:file, ':h'), 'p', 0700)
+        call writefile([a:profile], l:file)
+    catch
+        echohl WarningMsg
+        echomsg 'llama.vim: could not save profile state'
+        echohl None
+    endtry
+endfunction
+
+function! llama_profile#restore() abort
+    let l:file = s:profile_state_file()
+    if !filereadable(l:file)
+        return
+    endif
+
+    try
+        let l:profile = get(readfile(l:file), 0, '')
+    catch
+        return
+    endtry
+
+    if type(g:llama_config.profiles) == v:t_dict && has_key(g:llama_config.profiles, l:profile)
+        let g:llama_config.profile = l:profile
+    endif
+endfunction
+
+function! llama_profile#reset() abort
+    let g:llama_config.endpoint_fim   = s:default_endpoint_fim
+    let g:llama_config.endpoint_inst  = s:default_endpoint_inst
+    let g:llama_config.profile = s:default_profile
+
+    if !empty(s:default_profile)
+        call llama_profile#select(s:default_profile, v:true, v:false)
+    else
+        call llama#profile_changed()
+    endif
+
+    let l:file = s:profile_state_file()
+    if filereadable(l:file)
+        try
+            call delete(l:file)
+        catch
+            echohl WarningMsg
+            echomsg 'llama.vim: could not clear profile state'
+            echohl None
+            return
+        endtry
+    endif
+
+    echo 'Restored default llama profile: ' . (empty(s:default_profile)
+        \ ? '(custom endpoints)'
+        \ : s:default_profile)
+endfunction
+
+function! llama_profile#select(name, ...) abort
+    if empty(a:name)
+        let l:names = llama_profile#names()
+        let l:active = empty(g:llama_config.profile)
+            \ ? '(custom endpoints)'
+            \ : g:llama_config.profile
+        echo 'Active llama profile: ' . l:active
+        echo 'Available llama profiles: ' . (empty(l:names) ? '(none)' : join(l:names, ', '))
+        return
+    endif
+
+    if type(g:llama_config.profiles) != v:t_dict
+        echohl ErrorMsg
+        echo 'llama.vim: profiles must be a dictionary'
+        echohl None
+        return
+    endif
+
+    if !has_key(g:llama_config.profiles, a:name)
+        echohl ErrorMsg
+        echo 'llama.vim: unknown profile: ' . a:name
+        echohl None
+        return
+    endif
+
+    let l:base = g:llama_config.profiles[a:name]
+    if type(l:base) != v:t_string || empty(l:base)
+        echohl ErrorMsg
+        echo 'llama.vim: profile must contain a non-empty base URL: ' . a:name
+        echohl None
+        return
+    endif
+
+    let l:base = substitute(l:base, '/\+$', '', '')
+    let g:llama_config.endpoint_fim = l:base . '/infill'
+    let g:llama_config.endpoint_inst = l:base . '/v1/chat/completions'
+    let g:llama_config.profile = a:name
+
+        call llama#profile_changed()
+
+    if !get(a:, 1, v:false)
+        echo 'Using llama profile: ' . a:name . ' (' . l:base . ')'
+    endif
+
+    if get(a:, 2, !get(a:, 1, v:false))
+        call s:save_profile(a:name)
+    endif
+endfunction

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -60,19 +60,19 @@ Commands
 		Toggle autofim for this vim/nvim session
 		Equivalent to vimscript function: `llama#toggle_auto_fim()`
 
-*:LlamaServer*
+*:LlamaProfile*
 
-		Show the active and available named server profiles. Pass a profile
+		Show the active and available named profiles. Pass a profile
 		name to switch both FIM and instruction endpoints:
 
 >
-		:LlamaServer spark
+		:LlamaProfile spark
 <
 		Profile names support command-line completion.
 
 
-*:LlamaServerReset*
-		Discard the saved server-profile selection and restore the profile (or
+*:LlamaProfileReset*
+		Discard the saved profile selection and restore the profile (or
 		custom endpoints) configured when llama.vim was loaded, normally in
 		your .vimrc.
 
@@ -133,8 +133,8 @@ Currently the default config is:
 		let s:default_config = {
 		    \ 'endpoint_fim':           'http://127.0.0.1:8012/infill',
 		    \ 'endpoint_inst':          'http://127.0.0.1:8012/v1/chat/completions',
-		    \ 'server_profiles':        {},
-		    \ 'server_profile':         '',
+		    \ 'profiles':               {},
+		    \ 'profile':                '',
 		    \ 'model_fim':              '',
 		    \ 'model_inst':             '',
 		    \ 'api_key':                '',
@@ -175,13 +175,13 @@ Currently the default config is:
 
 - {endpoint_inst}		llama.cpp server endpoint for instruction completion
 
-- {server_profiles}		dictionary of named llama.cpp server base URLs. Selecting
+- {profiles}		    dictionary of named llama.cpp server base URLs. Selecting
 						a profile sets both endpoint_fim and endpoint_inst.
 
-- {server_profile}		server profile selected at startup. Leave empty to use
+- {profile}		        profile selected at startup. Leave empty to use
 						endpoint_fim and endpoint_inst directly.
-						A profile selected with |:LlamaServer| is saved between
-						sessions and takes precedence until |:LlamaServerReset|.
+						A profile selected with |:LlamaProfile| is saved between
+						sessions and takes precedence until |:LlamaProfileReset|.
 
 - {api_key}				llama.cpp server api key (optional)
 
@@ -321,17 +321,17 @@ Example:
 <
 5. Configure and switch between named llama.cpp servers:
 >vim
-		let g:llama_config.server_profiles = {
+		let g:llama_config.profiles = {
 		    \ 'spark':  'http://192.168.0.66:8080',
 		    \ 'gmktec': 'http://192.168.0.65:8080',
 		    \ }
-		let g:llama_config.server_profile = 'spark'
+		let g:llama_config.profile = 'spark'
 
 		" Show the active and available profiles.
-		:LlamaServer
+		:LlamaProfile
 
 		" Switch FIM and instruction requests to another server.
-		:LlamaServer workstation
+		:LlamaProfile gmktec
 <
 To adjust the colors for hint and info texts, `llama.vim` provides the
 highlight group `llama_hl_fim_hint` and `llama_hl_fim_info`. You can modify these

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -62,6 +62,12 @@ Commands
 <
 		Profile names support command-line completion.
 
+
+*:LlamaServerReset*
+		Discard the saved server-profile selection and restore the profile (or
+		custom endpoints) configured when llama.vim was loaded, normally in
+		your .vimrc.
+
 *:LlamaInstruct*
 		Trigger instruction-based editing (instruct mode) on selected text
 
@@ -162,10 +168,12 @@ Currently the default config is:
 - {endpoint_inst}		llama.cpp server endpoint for instruction completion
 
 - {server_profiles}		dictionary of named llama.cpp server base URLs. Selecting
-					a profile sets both endpoint_fim and endpoint_inst.
+						a profile sets both endpoint_fim and endpoint_inst.
 
 - {server_profile}		server profile selected at startup. Leave empty to use
-					endpoint_fim and endpoint_inst directly.
+						endpoint_fim and endpoint_inst directly.
+						A profile selected with |:LlamaServer| is saved between
+						sessions and takes precedence until |:LlamaServerReset|.
 
 - {api_key}				llama.cpp server api key (optional)
 

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -52,6 +52,16 @@ Commands
 		Toggle autofim for this vim/nvim session
 		Equivalent to vimscript function: `llama#toggle_auto_fim()`
 
+*:LlamaServer*
+
+		Show the active and available named server profiles. Pass a profile
+		name to switch both FIM and instruction endpoints:
+
+>
+		:LlamaServer spark
+<
+		Profile names support command-line completion.
+
 *:LlamaInstruct*
 		Trigger instruction-based editing (instruct mode) on selected text
 
@@ -109,6 +119,8 @@ Currently the default config is:
 		let s:default_config = {
 		    \ 'endpoint_fim':           'http://127.0.0.1:8012/infill',
 		    \ 'endpoint_inst':          'http://127.0.0.1:8012/v1/chat/completions',
+		    \ 'server_profiles':        {},
+		    \ 'server_profile':         '',
 		    \ 'model_fim':              '',
 		    \ 'model_inst':             '',
 		    \ 'api_key':                '',
@@ -148,6 +160,12 @@ Currently the default config is:
 - {endpoint_fim}		llama.cpp server endpoint for FIM completion
 
 - {endpoint_inst}		llama.cpp server endpoint for instruction completion
+
+- {server_profiles}		dictionary of named llama.cpp server base URLs. Selecting
+					a profile sets both endpoint_fim and endpoint_inst.
+
+- {server_profile}		server profile selected at startup. Leave empty to use
+					endpoint_fim and endpoint_inst directly.
 
 - {api_key}				llama.cpp server api key (optional)
 
@@ -276,6 +294,20 @@ Example:
 				}
 			end,
 		}
+<
+5. Configure and switch between named llama.cpp servers:
+>vim
+		let g:llama_config.server_profiles = {
+		    \ 'spark':  'http://192.168.0.66:8080',
+		    \ 'gmktec': 'http://192.168.0.65:8080',
+		    \ }
+		let g:llama_config.server_profile = 'spark'
+
+		" Show the active and available profiles.
+		:LlamaServer
+
+		" Switch FIM and instruction requests to another server.
+		:LlamaServer workstation
 <
 To adjust the colors for hint and info texts, `llama.vim` provides the
 highlight group `llama_hl_fim_hint` and `llama_hl_fim_info`. You can modify these

--- a/doc/tags
+++ b/doc/tags
@@ -1,2 +1,3 @@
+:LlamaServer	llama.txt	/*:LlamaServer*
 llama	llama.txt	/*llama*
 llama_config	llama.txt	/*llama_config*

--- a/doc/tags
+++ b/doc/tags
@@ -3,8 +3,9 @@
 :LlamaDisable	llama.txt	/*:LlamaDisable*
 :LlamaEnable	llama.txt	/*:LlamaEnable*
 :LlamaInstruct	llama.txt	/*:LlamaInstruct*
+:LlamaProfile	llama.txt	/*:LlamaProfile*
+:LlamaProfileReset	llama.txt	/*:LlamaProfileReset*
 :LlamaToggle	llama.txt	/*:LlamaToggle*
 :LlamaToggleAutoFim	llama.txt	/*:LlamaToggleAutoFim*
-:LlamaServer	llama.txt	/*:LlamaServer*
 llama	llama.txt	/*llama*
 llama_config	llama.txt	/*llama_config*


### PR DESCRIPTION
This commit adds a feature that enables named server profiles to be configured.

The motivation for this is feature is that I have a few machines that I uses as llama-servers for llama.vim. But sometimes I have to work on the machines and therefor I have to shutdown that server. This means I have to update my llama_config to point to my other server while I'm my other machine is occupied. With this feature it is possible to store multiple configurations and then use the LlamaServer command to switch to a different server profile and keep working locally.

### Example usage:
List profiles:
```console
:LlamaServer
Active llama server: spark
Available llama servers: gmktec, spark
```
Switch profile:
```console
:LlamaServer gmktec
Using llama server: gmktec (http://192.168.0.65:8080)

```

__TODO__: ~make the profile choice persistent. Currently the change is lost as the change is only done in the current session.~