### PR TITLE
docs : fix stale keymap defaults and a wrong option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Examples:
 
     ```vim
     let g:llama_config.keymap_inst_trigger  = "<leader>lli"
-    let g:llama_config.keymap_inst_retry    = "<leader>llr"
+    let g:llama_config.keymap_inst_rerun    = "<leader>llr"
     let g:llama_config.keymap_inst_continue = "<leader>llc"
     let g:llama_config.keymap_inst_accept   = "<Tab>"
     let g:llama_config.keymap_inst_cancel   = "<Esc>"

--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -54,13 +54,13 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "
 " keymaps parameters (empty string to disable):
 "
-"   keymap_fim_trigger:     keymap to trigger the completion, default: <C-F>
+"   keymap_fim_trigger:     keymap to trigger the completion, default: <leader>llf
 "   keymap_fim_accept_full: keymap to accept full suggestion, default: <Tab>
 "   keymap_fim_accept_line: keymap to accept line suggestion, default: <S-Tab>
-"   keymap_fim_accept_word: keymap to accept word suggestion, default: <C-B>
+"   keymap_fim_accept_word: keymap to accept word suggestion, default: <leader>ll]
 "   keymap_fim_next:        keymap to cycle to next completion,  default: <C-J>
 "   keymap_fim_prev:        keymap to cycle to prev completion,  default: <C-K>
-"   keymap_debug_toggle:    keymap to toggle the debug pane,  default: null
+"   keymap_debug_toggle:    keymap to toggle the debug pane,  default: <leader>lld
 "   keymap_inst_trigger:    keymap to trigger the instruction command, default: <leader>lli
 "   keymap_inst_rerun:      keymap to rerun the instruction, default: <leader>llr
 "   keymap_inst_continue:   keymap to continue the instruction, default: <leader>llc

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -16,13 +16,21 @@ Requires:
 ================================================================================
 Default Shortcut
 
+insert mode:
+
 - Tab         - accept the current suggestion
 - Shift+Tab   - accept just the first line of the suggestion
 - <leader>ll] - accept just the first word of the suggestion
 - <C-J>       - cycle to next completion (when multiple are available)
 - <C-K>       - cycle to previous completion (when multiple are available)
 - <leader>llf - trigger FIM completion manually
+
+visual mode:
+
 - <leader>lli - trigger instruction-based editing (instruct mode)
+
+normal mode:
+
 - <leader>llr - rerun the instruction
 - <leader>llc - continue the instruction
 - Tab         - accept the instruction

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -25,8 +25,8 @@ Default Shortcut
 - <leader>lli - trigger instruction-based editing (instruct mode)
 - <leader>llr - rerun the instruction
 - <leader>llc - continue the instruction
-- <leader>llr - accept the instruction (accept the instruction)
-- <leader>llq - cancel the instruction (cancel the instruction)
+- Tab         - accept the instruction
+- Esc         - cancel the instruction
 - <leader>lld - toggle the debug pane
 
 ================================================================================
@@ -117,7 +117,7 @@ Currently the default config is:
 		    \ 'n_predict':              128,
 		    \ 'n_cmpl':                 1,
 		    \ 'stop_strings_fim':       [],
- 			\ 'stop_strings_inst':      [],
+		    \ 'stop_strings_inst':      [],
 		    \ 't_max_prompt_ms':        500,
 		    \ 't_max_predict_ms':       1000,
 		    \ 'show_info':              2,
@@ -217,21 +217,29 @@ parameters for the ring-buffer with extra context:
 
 keymaps parameters:
 
-- {keymap_fim_trigger}		keymap to trigger the auto completion, default: <C-F>
+- {keymap_fim_trigger}		keymap to trigger the auto completion, default: <leader>llf
 
 - {keymap_fim_accept_full}	keymap to accept full suggestion, default: <Tab>
 
 - {keymap_fim_accept_line}	keymap to accept line suggestion, default: <S-Tab>
 
-- {keymap_fim_accept_word}	keymap to accept word suggestion, default: <C-B>
+- {keymap_fim_accept_word}	keymap to accept word suggestion, default: <leader>ll]
 
 - {keymap_fim_next}		keymap to cycle to next completion, default: <C-J>
 
 - {keymap_fim_prev}		keymap to cycle to previous completion, default: <C-K>
 
-- {keymap_inst_trigger}		keymap to trigger instruction-based editing, default: null
+- {keymap_inst_trigger}		keymap to trigger instruction-based editing, default: <leader>lli
 
-- {keymap_debug_toggle}		keymap to toggle the debug pane, default: null
+- {keymap_inst_rerun}		keymap to rerun the instruction, default: <leader>llr
+
+- {keymap_inst_continue}	keymap to continue the instruction, default: <leader>llc
+
+- {keymap_inst_accept}		keymap to accept the instruction, default: <Tab>
+
+- {keymap_inst_cancel}		keymap to cancel the instruction, default: <Esc>
+
+- {keymap_debug_toggle}		keymap to toggle the debug pane, default: <leader>lld
 
 Example:
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,2 +1,9 @@
+:LlamaDebugClear	llama.txt	/*:LlamaDebugClear*
+:LlamaDebugToggle	llama.txt	/*:LlamaDebugToggle*
+:LlamaDisable	llama.txt	/*:LlamaDisable*
+:LlamaEnable	llama.txt	/*:LlamaEnable*
+:LlamaInstruct	llama.txt	/*:LlamaInstruct*
+:LlamaToggle	llama.txt	/*:LlamaToggle*
+:LlamaToggleAutoFim	llama.txt	/*:LlamaToggleAutoFim*
 llama	llama.txt	/*llama*
 llama_config	llama.txt	/*llama_config*


### PR DESCRIPTION
The documented defaults for several keymaps have drifted from `s:default_config`:

| option | documented | actual |
| --- | --- | --- |
| `keymap_fim_trigger` | `<C-F>` | `<leader>llf` |
| `keymap_fim_accept_word` | `<C-B>` | `<leader>ll]` |
| `keymap_inst_trigger` | `null` | `<leader>lli` |
| `keymap_debug_toggle` | `null` | `<leader>lld` |

Fixed in both `doc/llama.txt` and the comment block at the top of `autoload/llama.vim`.

While there:

- The keymaps section of the help file was missing `keymap_inst_rerun`, `keymap_inst_continue`, `keymap_inst_accept` and `keymap_inst_cancel` — added.
- The shortcut list at the top of `doc/llama.txt` said the instruction is accepted with `<leader>llr` (a duplicate of rerun) and cancelled with `<leader>llq`, which is not bound to anything. They are `<Tab>` and `<Esc>`.
- `README.md` step 5 told users to set `keymap_inst_retry`. There is no such option; it is `keymap_inst_rerun`. Since the config is merged with `extendnew(..., 'force')`, following the README added a dead key and silently left rerun at its default:

  ```
  keymap_inst_retry = ',,retry'  ->  maparg(',,retry', 'n') == ''
  keymap_inst_rerun = ',,rerun'  ->  maparg(',,rerun', 'n') == ':call llama#inst_rerun()<CR>'
  ```

- Regenerated `doc/tags`. The committed file predates the `:Llama*` commands, so on a plain clone `:help :LlamaDisable`, `:LlamaEnable`, `:LlamaToggle`, `:LlamaToggleAutoFim`, `:LlamaInstruct`, `:LlamaDebugClear` and `:LlamaDebugToggle` all fail with `E149` unless the user runs `:helptags` themselves. All nine tags in the file resolve after the change, in both nvim 0.12.2 and vim 9.1.

No functional changes.

### Testing

Wrote a checker that loads the plugin, dumps the live `g:llama_config`, and compares it against every default claimed in `doc/llama.txt` and `autoload/llama.vim`, plus every `g:llama_config.X` assignment in `README.md`. On master it reports 11 failures; on this branch it passes. `nvim` and `vim` produce an identical config dump.

Related: #1
