### PR TITLE
core : fix chunk similarity token occurrence counting

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -586,14 +586,16 @@ function! s:chunk_sim(c0, c1)
     let l:tokens0 = split(join(a:c0, "\n"), '\W\+')
     let l:tokens1 = split(join(a:c1, "\n"), '\W\+')
 
-    let l:set0 = {}
+    let l:count0 = {}
     for l:tok in l:tokens0
-        let l:set0[l:tok] = 1
+        let l:count0[l:tok] = get(l:count0, l:tok, 0) + 1
     endfor
 
+    " Do not match the same occurrence from c0 more than once.
     let l:common = 0
     for l:tok in l:tokens1
-        if has_key(l:set0, l:tok)
+        if get(l:count0, l:tok, 0) > 0
+            let l:count0[l:tok] -= 1
             let l:common += 1
         endif
     endfor


### PR DESCRIPTION
Fixes #82.

### Problem

`s:chunk_sim()` is documented as returning a similarity score where 0 means no similarity and 1 means high similarity. The token-based implementation built a set from the first chunk but counted every matching token in the second chunk, so repeated tokens in the second chunk could make the score exceed 1 and make the result depend on argument order.

### Cause

The first chunk was reduced to token presence while the second chunk still used token multiplicity. For `['foo']` compared with `['foo foo foo']`, the same `foo` occurrence from the first chunk was matched three times.

### Fix

Track token occurrence counts for the first chunk and decrement each count when it is matched. This keeps the Dice-style score symmetric and bounded by 1 while preserving the existing tokenization and scoring formula.

### Testing

Upstream-base RED, using a headless Vim harness against `origin/master`:

```text
FAIL chunk_sim
command line..script .../chunk_sim_harness.vim line 15: single token vs repeated token should count one shared occurrence: Expected 0.5 but got 1.5
command line..script .../chunk_sim_harness.vim line 16: chunk similarity should be symmetric: Expected 0.5 but got 1.5
left=1.500000 right=0.500000 identical=1.000000
release_rc=0
smoke_rc=0
harness_rc=1
```

Patched GREEN, using the same harness with Vim 9.1:

```text
PASS chunk_sim
left=0.500000 right=0.500000 identical=1.000000
release_rc=0
smoke_rc=0
harness_rc=0
```

Patched GREEN, using the same harness with Neovim 0.11.1 in `alpine:3.22`:

```text
PASS chunk_sim
left=0.500000 right=0.500000 identical=1.000000
release_rc=0
smoke_rc=0
harness_rc=0
```

Full local suite:

```text
baseline origin/master: scripts/make-release-checks.sh fails because tag v0.1.0 already exists; Vim source smoke passes; chunk_sim harness fails as shown above.
final branch: same release-tag failure; Vim source smoke passes; chunk_sim harness passes.
```

Changed-line coverage was checked with Vim `:profile func *chunk_sim*`; the harness called `s:chunk_sim()` three times and executed the changed occurrence-counting lines.

### AI usage disclosure

YES. pi:llama.cpp/gpt-5-codex was used to inspect the issue, build the headless Vim/Neovim harness, and prepare this patch.
