### PR TITLE
fim : use <C-L> instead of <C-K> for keymap_fim_prev

### DIFF
--- a/autoload/llama.vim
+++ b/autoload/llama.vim
@@ -61,7 +61,7 @@ highlight default llama_hl_fim_info guifg=#77ff2f ctermfg=119
 "   keymap_fim_accept_line: keymap to accept line suggestion, default: <S-Tab>
 "   keymap_fim_accept_word: keymap to accept word suggestion, default: <leader>ll]
 "   keymap_fim_next:        keymap to cycle to next completion,  default: <C-J>
-"   keymap_fim_prev:        keymap to cycle to prev completion,  default: <C-K>
+"   keymap_fim_prev:        keymap to cycle to prev completion,  default: <C-L>
 "   keymap_debug_toggle:    keymap to toggle the debug pane,  default: <leader>lld
 "   keymap_inst_trigger:    keymap to trigger the instruction command, default: <leader>lli
 "   keymap_inst_rerun:      keymap to rerun the instruction, default: <leader>llr
@@ -99,7 +99,7 @@ let s:default_config = {
     \ 'keymap_fim_accept_line': "<S-Tab>",
     \ 'keymap_fim_accept_word': "<leader>ll]",
     \ 'keymap_fim_next':        "<C-J>",
-    \ 'keymap_fim_prev':        "<C-K>",
+    \ 'keymap_fim_prev':        "<C-L>",
     \ 'keymap_inst_trigger':    "<leader>lli",
     \ 'keymap_inst_rerun':      "<leader>llr",
     \ 'keymap_inst_continue':   "<leader>llc",

--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -22,7 +22,7 @@ insert mode:
 - Shift+Tab   - accept just the first line of the suggestion
 - <leader>ll] - accept just the first word of the suggestion
 - <C-J>       - cycle to next completion (when multiple are available)
-- <C-K>       - cycle to previous completion (when multiple are available)
+- <C-L>       - cycle to previous completion (when multiple are available)
 - <leader>llf - trigger FIM completion manually
 
 visual mode:
@@ -160,7 +160,7 @@ Currently the default config is:
 		    \ 'keymap_fim_accept_line': "<S-Tab>",
 		    \ 'keymap_fim_accept_word': "<leader>ll]",
 		    \ 'keymap_fim_next':        "<C-J>",
-		    \ 'keymap_fim_prev':        "<C-K>",
+		    \ 'keymap_fim_prev':        "<C-L>",
 		    \ 'keymap_inst_trigger':    "<leader>lli",
 		    \ 'keymap_inst_rerun':      "<leader>llr",
 		    \ 'keymap_inst_continue':   "<leader>llc",
@@ -261,7 +261,7 @@ keymaps parameters:
 
 - {keymap_fim_next}		keymap to cycle to next completion, default: <C-J>
 
-- {keymap_fim_prev}		keymap to cycle to previous completion, default: <C-K>
+- {keymap_fim_prev}		keymap to cycle to previous completion, default: <C-L>
 
 - {keymap_inst_trigger}		keymap to trigger instruction-based editing, default: <leader>lli
 


### PR DESCRIPTION
This commit changes the keymap for cycling to the previous completion from \<C-K\> to \<C-L\>.

The motivation for this change is that \<C-K\> is vim's default key combination for digraphs and it currently does not work when llama.vim is enabled. Using \<C-L\> I was thinking of the right navigation key, I also considered using \<C-P\> (for previous) but that would not be consistent with \<C-J\> I don't think.